### PR TITLE
Add CI/CD workflow and update image references

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,110 @@
+name: Build and Push
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: bapalm/tls-compliance-operator
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: make test
+
+  build-and-push:
+    name: Build and Push Multi-Arch Image
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # Required for cosign keyless signing with GitHub OIDC
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Set latest tag for main branch (built on every PR merge)
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # Set stable tag for releases
+            type=raw,value=stable,enable=${{ github.event_name == 'release' }}
+            # Set version tags for releases (v0.1.0)
+            type=semver,pattern=v{{version}},enable=${{ github.event_name == 'release' }}
+            # Set minor version tag (v0.1)
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            # Set major version tag (v0)
+            type=semver,pattern=v{{major}},enable=${{ github.event_name == 'release' }}
+            # Set SHA tag for traceability
+            type=sha,prefix=,format=short
+
+      - name: Build and push multi-arch image
+        id: build-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign container image with cosign
+        env:
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Sign the image by digest for each tag
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+
+      - name: Verify container image signature
+        env:
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+        run: |
+          cosign verify \
+            --certificate-identity-regexp="https://github.com/${{ github.repository }}/*" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,9 @@ make manifests                # Regenerate CRDs/RBAC from kubebuilder markers
 make generate                 # Regenerate DeepCopy methods
 
 # Docker
-make docker-build IMG=<img>   # Build image
-make docker-push IMG=<img>    # Push image
-make docker-buildx IMG=<img>  # Multi-arch build (amd64, arm64, s390x, ppc64le)
+make docker-build IMG=quay.io/bapalm/tls-compliance-operator:latest   # Build image
+make docker-push IMG=quay.io/bapalm/tls-compliance-operator:latest    # Push image
+make docker-buildx IMG=quay.io/bapalm/tls-compliance-operator:latest  # Multi-arch build (amd64, arm64, s390x, ppc64le)
 
 # Deploy to cluster
 make install                  # Install CRDs only

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= quay.io/bapalm/tls-compliance-operator:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/README.md
+++ b/README.md
@@ -88,17 +88,17 @@ versions, cipher suites, and certificate details.
 
 ```bash
 # Build and push to your registry
-make docker-build docker-push IMG=quay.io/youruser/tls-compliance-operator:latest
+make docker-build docker-push IMG=quay.io/bapalm/tls-compliance-operator:latest
 
 # Install CRDs and deploy
 make install
-make deploy IMG=quay.io/youruser/tls-compliance-operator:latest
+make deploy IMG=quay.io/bapalm/tls-compliance-operator:latest
 ```
 
 ### Or Generate Install Manifest
 
 ```bash
-make build-installer IMG=quay.io/youruser/tls-compliance-operator:latest
+make build-installer IMG=quay.io/bapalm/tls-compliance-operator:latest
 kubectl apply -f dist/install.yaml
 ```
 
@@ -223,7 +223,7 @@ make manifests generate
 make test-e2e       # Creates Kind cluster, runs tests, cleans up
 
 # Multi-arch build
-make docker-buildx IMG=quay.io/youruser/tls-compliance-operator:latest
+make docker-buildx IMG=quay.io/bapalm/tls-compliance-operator:latest
 ```
 
 ## Contributing

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: localhost/tls-compliance-operator
-  newTag: dev
+  newName: quay.io/bapalm/tls-compliance-operator
+  newTag: latest


### PR DESCRIPTION
## Summary
- Add GitHub Actions `build-push.yml` workflow for automated multi-arch image builds (amd64, arm64, s390x, ppc64le) with cosign keyless signing via GitHub OIDC
- Update all image references from placeholders (`controller:latest`, `localhost/tls-compliance-operator:dev`, `quay.io/youruser/...`) to `quay.io/bapalm/tls-compliance-operator`
- Files updated: Makefile, `config/manager/kustomization.yaml`, README.md, CLAUDE.md

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] Verify workflow triggers on merge to `main`
- [ ] Confirm image appears at `quay.io/bapalm/tls-compliance-operator`
- [ ] Verify `QUAY_USERNAME` and `QUAY_PASSWORD` secrets are configured in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)