### PR TITLE
Add --include-namespaces flag for include-mode namespace filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The operator accepts the following command-line flags:
 | `--tls-check-timeout` | `5s` | Timeout per TLS connection attempt |
 | `--rate-limit` | `10.0` | TLS checks per second |
 | `--rate-burst` | `20` | Rate limiter burst size |
+| `--include-namespaces` | `""` | Comma-separated namespaces to exclusively monitor (overrides exclude) |
 | `--exclude-namespaces` | `""` | Comma-separated namespaces to skip |
 | `--cert-expiry-warning-days` | `30` | Days before expiry to emit warnings |
 | `--metrics-bind-address` | `0` | Metrics endpoint bind address |

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: tlscompliancereports.security.telco.openshift.io
 spec:
   group: security.telco.openshift.io


### PR DESCRIPTION
## Summary
- Adds `--include-namespaces` flag to complement `--exclude-namespaces`
- When set, only the listed namespaces are monitored for TLS endpoints
- Takes precedence over `--exclude-namespaces` with a logged warning if both are set
- Replaces `isExcludedNamespace()` with `isNamespaceFiltered()` using `slices.Contains`
- Updates README configuration table with the new flag

Closes #9

## Test plan
- [x] Unit tests for include-mode filtering
- [x] Unit tests for include-overrides-exclude behavior
- [x] Unit tests for neither-set (existing behavior preserved)
- [x] Reconcile-level test verifying only included namespaces produce CRs
- [x] All existing tests pass
- [x] Lint clean (0 issues)

Generated with [Claude Code](https://claude.com/claude-code)