### PR TITLE
Add finer-grained failure statuses: Timeout, Closed, Filtered

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ kubectl apply -f dist/install.yaml
 |--------|-----------|
 | **Compliant** | Supports TLS 1.2 or 1.3 (supporting older versions alongside is fine) |
 | **NonCompliant** | Only supports TLS 1.0/1.1 with no modern TLS |
-| **Unreachable** | Could not connect to endpoint (connection refused, timeout) |
+| **Timeout** | Connection timed out waiting for a response |
+| **Closed** | Port is not listening (connection refused) |
+| **Filtered** | No response and no explicit refusal (e.g. firewall drop) |
+| **Unreachable** | Could not connect to endpoint (unclassified network error) |
 | **NoTLS** | Port is open but does not speak TLS |
 | **MutualTLSRequired** | Server requires a client certificate to complete handshake |
 | **Pending** | Not yet checked |

--- a/api/v1alpha1/tlscompliancereport_types.go
+++ b/api/v1alpha1/tlscompliancereport_types.go
@@ -31,7 +31,7 @@ const (
 )
 
 // ComplianceStatus indicates the TLS compliance status of an endpoint
-// +kubebuilder:validation:Enum=Compliant;NonCompliant;Warning;Unreachable;NoTLS;MutualTLSRequired;Pending;Unknown
+// +kubebuilder:validation:Enum=Compliant;NonCompliant;Warning;Unreachable;Timeout;Closed;Filtered;NoTLS;MutualTLSRequired;Pending;Unknown
 type ComplianceStatus string
 
 const (
@@ -41,8 +41,14 @@ const (
 	ComplianceStatusNonCompliant ComplianceStatus = "NonCompliant"
 	// ComplianceStatusWarning means TLS 1.3 not supported but no legacy TLS
 	ComplianceStatusWarning ComplianceStatus = "Warning"
-	// ComplianceStatusUnreachable means the endpoint could not be reached
+	// ComplianceStatusUnreachable means the endpoint could not be reached (generic failure)
 	ComplianceStatusUnreachable ComplianceStatus = "Unreachable"
+	// ComplianceStatusTimeout means the connection timed out waiting for a response
+	ComplianceStatusTimeout ComplianceStatus = "Timeout"
+	// ComplianceStatusClosed means the port is not listening (connection refused)
+	ComplianceStatusClosed ComplianceStatus = "Closed"
+	// ComplianceStatusFiltered means no response and no explicit refusal (e.g. firewall drop)
+	ComplianceStatusFiltered ComplianceStatus = "Filtered"
 	// ComplianceStatusNoTLS means the port is open but does not speak TLS
 	ComplianceStatusNoTLS ComplianceStatus = "NoTLS"
 	// ComplianceStatusMutualTLSRequired means the server requires a client certificate

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
@@ -161,6 +161,9 @@ spec:
                 - NonCompliant
                 - Warning
                 - Unreachable
+                - Timeout
+                - Closed
+                - Filtered
                 - NoTLS
                 - MutualTLSRequired
                 - Pending

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -271,6 +271,12 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 			cr.Status.ComplianceStatus = securityv1alpha1.ComplianceStatusNoTLS
 		case tlscheck.FailureReasonMutualTLSRequired:
 			cr.Status.ComplianceStatus = securityv1alpha1.ComplianceStatusMutualTLSRequired
+		case tlscheck.FailureReasonTimeout:
+			cr.Status.ComplianceStatus = securityv1alpha1.ComplianceStatusTimeout
+		case tlscheck.FailureReasonClosed:
+			cr.Status.ComplianceStatus = securityv1alpha1.ComplianceStatusClosed
+		case tlscheck.FailureReasonFiltered:
+			cr.Status.ComplianceStatus = securityv1alpha1.ComplianceStatusFiltered
 		default:
 			cr.Status.ComplianceStatus = securityv1alpha1.ComplianceStatusUnreachable
 		}
@@ -584,6 +590,9 @@ func (r *EndpointReconciler) updateEndpointMetrics(ctx context.Context) {
 		string(securityv1alpha1.ComplianceStatusNonCompliant):      0,
 		string(securityv1alpha1.ComplianceStatusWarning):           0,
 		string(securityv1alpha1.ComplianceStatusUnreachable):       0,
+		string(securityv1alpha1.ComplianceStatusTimeout):           0,
+		string(securityv1alpha1.ComplianceStatusClosed):            0,
+		string(securityv1alpha1.ComplianceStatusFiltered):          0,
 		string(securityv1alpha1.ComplianceStatusNoTLS):             0,
 		string(securityv1alpha1.ComplianceStatusMutualTLSRequired): 0,
 		string(securityv1alpha1.ComplianceStatusPending):           0,

--- a/pkg/tlscheck/types.go
+++ b/pkg/tlscheck/types.go
@@ -27,8 +27,14 @@ type FailureReason string
 const (
 	// FailureReasonNone indicates the check succeeded
 	FailureReasonNone FailureReason = ""
-	// FailureReasonUnreachable indicates a network-level failure (connection refused, timeout)
+	// FailureReasonUnreachable indicates a generic network-level failure
 	FailureReasonUnreachable FailureReason = "Unreachable"
+	// FailureReasonTimeout indicates the connection timed out waiting for a response
+	FailureReasonTimeout FailureReason = "Timeout"
+	// FailureReasonClosed indicates the port is not listening (connection refused)
+	FailureReasonClosed FailureReason = "Closed"
+	// FailureReasonFiltered indicates no response and no explicit refusal (e.g. firewall drop)
+	FailureReasonFiltered FailureReason = "Filtered"
 	// FailureReasonNoTLS indicates the port is open but does not speak TLS
 	FailureReasonNoTLS FailureReason = "NoTLS"
 	// FailureReasonMutualTLSRequired indicates the server requires a client certificate


### PR DESCRIPTION
## Summary
- Replaces catch-all `Unreachable` status with specific failure modes: `Timeout`, `Closed`, `Filtered`
- `Timeout`: connection timed out (detected via `net.Error` interface and string patterns)
- `Closed`: connection refused / port not listening
- `Filtered`: reserved for firewall drops (no response, no refusal)
- `Unreachable`: preserved as fallback for unclassified errors
- Updates CRD enum, controller mapping, metrics counters, and README compliance table

Closes #13

## Test plan
- [x] Unit tests for each new failure reason in `classifyFailure()`
- [x] Priority ordering tests (mTLS > NoTLS > Closed > Timeout > Unreachable)
- [x] Integration test updated: port 1 now correctly classifies as `Closed`
- [x] All existing tests pass
- [x] Lint clean (0 issues)

Generated with [Claude Code](https://claude.com/claude-code)