### PR TITLE
Add cipher strength grading (A-F) for TLS cipher suites

### DIFF
--- a/api/v1alpha1/tlscompliancereport_types.go
+++ b/api/v1alpha1/tlscompliancereport_types.go
@@ -136,6 +136,14 @@ type TLSComplianceReportStatus struct {
 	// +optional
 	CipherSuites map[string][]string `json:"cipherSuites,omitempty"`
 
+	// CipherStrengthGrades maps each cipher suite name to its strength grade (A-F)
+	// +optional
+	CipherStrengthGrades map[string]string `json:"cipherStrengthGrades,omitempty"`
+
+	// OverallCipherGrade is the worst grade across all negotiated cipher suites
+	// +optional
+	OverallCipherGrade string `json:"overallCipherGrade,omitempty"`
+
 	// NegotiatedCurves maps TLS version to the negotiated key exchange curve
 	// (e.g. X25519, P-256, X25519MLKEM768)
 	// +optional
@@ -188,6 +196,7 @@ type TLSComplianceReportStatus struct {
 // +kubebuilder:printcolumn:name="Port",type=integer,JSONPath=`.spec.port`
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.sourceKind`
 // +kubebuilder:printcolumn:name="Compliance",type=string,JSONPath=`.status.complianceStatus`
+// +kubebuilder:printcolumn:name="Grade",type=string,JSONPath=`.status.overallCipherGrade`
 // +kubebuilder:printcolumn:name="TLS1.3",type=boolean,JSONPath=`.status.tlsVersions.tls13`
 // +kubebuilder:printcolumn:name="TLS1.2",type=boolean,JSONPath=`.status.tlsVersions.tls12`
 // +kubebuilder:printcolumn:name="TLS1.0",type=boolean,JSONPath=`.status.tlsVersions.tls10`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -147,6 +147,13 @@ func (in *TLSComplianceReportStatus) DeepCopyInto(out *TLSComplianceReportStatus
 			(*out)[key] = outVal
 		}
 	}
+	if in.CipherStrengthGrades != nil {
+		in, out := &in.CipherStrengthGrades, &out.CipherStrengthGrades
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NegotiatedCurves != nil {
 		in, out := &in.NegotiatedCurves, &out.NegotiatedCurves
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.complianceStatus
       name: Compliance
       type: string
+    - jsonPath: .status.overallCipherGrade
+      name: Grade
+      type: string
     - jsonPath: .status.tlsVersions.tls13
       name: TLS1.3
       type: boolean
@@ -144,6 +147,12 @@ spec:
                 description: CheckCount is the number of TLS checks performed
                 format: int64
                 type: integer
+              cipherStrengthGrades:
+                additionalProperties:
+                  type: string
+                description: CipherStrengthGrades maps each cipher suite name to its
+                  strength grade (A-F)
+                type: object
               cipherSuites:
                 additionalProperties:
                   items:
@@ -256,6 +265,10 @@ spec:
                   NegotiatedCurves maps TLS version to the negotiated key exchange curve
                   (e.g. X25519, P-256, X25519MLKEM768)
                 type: object
+              overallCipherGrade:
+                description: OverallCipherGrade is the worst grade across all negotiated
+                  cipher suites
+                type: string
               quantumReady:
                 description: |-
                   QuantumReady indicates whether any TLS connection negotiated a

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -304,8 +304,10 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 		TLS13: result.SupportsTLS13,
 	}
 
-	// Update cipher suites
+	// Update cipher suites and grades
 	cr.Status.CipherSuites = result.CipherSuites
+	cr.Status.CipherStrengthGrades = tlscheck.GradeCipherSuites(result.CipherSuites)
+	cr.Status.OverallCipherGrade = tlscheck.OverallGrade(result.CipherSuites)
 
 	// Update negotiated curves and quantum readiness
 	cr.Status.NegotiatedCurves = result.NegotiatedCurves

--- a/pkg/tlscheck/ciphergrade.go
+++ b/pkg/tlscheck/ciphergrade.go
@@ -1,0 +1,97 @@
+package tlscheck
+
+import "strings"
+
+// CipherGrade represents the strength grade of a cipher suite.
+type CipherGrade string
+
+const (
+	// GradeA represents AEAD ciphers with ephemeral key exchange (all TLS 1.3, GCM/ChaCha20 with ECDHE/DHE).
+	GradeA CipherGrade = "A"
+	// GradeB represents CBC ciphers with ephemeral key exchange (forward secrecy but no AEAD).
+	GradeB CipherGrade = "B"
+	// GradeC represents RSA key exchange ciphers (no forward secrecy).
+	GradeC CipherGrade = "C"
+	// GradeD represents weak ciphers (3DES, RC4).
+	GradeD CipherGrade = "D"
+	// GradeF represents NULL or export ciphers.
+	GradeF CipherGrade = "F"
+)
+
+// gradeOrder defines grade ordering from best to worst for comparison.
+var gradeOrder = map[CipherGrade]int{
+	GradeA: 0,
+	GradeB: 1,
+	GradeC: 2,
+	GradeD: 3,
+	GradeF: 4,
+}
+
+// GradeCipherSuite returns the strength grade for a given IANA cipher suite name.
+func GradeCipherSuite(name string) CipherGrade {
+	// NULL or export ciphers
+	if strings.Contains(name, "NULL") || strings.Contains(name, "EXPORT") {
+		return GradeF
+	}
+
+	// Weak ciphers: 3DES and RC4
+	if strings.Contains(name, "3DES") || strings.Contains(name, "RC4") {
+		return GradeD
+	}
+
+	// TLS 1.3 ciphers are all Grade A (AEAD with ephemeral key exchange)
+	if !strings.Contains(name, "_WITH_") {
+		return GradeA
+	}
+
+	// Check for ephemeral key exchange (ECDHE or DHE)
+	hasEphemeral := strings.HasPrefix(name, "TLS_ECDHE_") || strings.HasPrefix(name, "TLS_DHE_")
+
+	// Check for AEAD cipher (GCM or CHACHA20_POLY1305)
+	isAEAD := strings.Contains(name, "GCM") || strings.Contains(name, "CHACHA20_POLY1305")
+
+	if hasEphemeral && isAEAD {
+		return GradeA
+	}
+	if hasEphemeral {
+		return GradeB
+	}
+
+	// RSA key exchange (no forward secrecy)
+	return GradeC
+}
+
+// GradeCipherSuites returns per-cipher grades for a map of TLS version to cipher suite names.
+func GradeCipherSuites(cipherSuites map[string][]string) map[string]string {
+	grades := make(map[string]string)
+	for _, suites := range cipherSuites {
+		for _, suite := range suites {
+			if _, exists := grades[suite]; !exists {
+				grades[suite] = string(GradeCipherSuite(suite))
+			}
+		}
+	}
+	return grades
+}
+
+// OverallGrade returns the worst (lowest) grade across all cipher suites.
+// Returns an empty string if no cipher suites are provided.
+func OverallGrade(cipherSuites map[string][]string) string {
+	worst := GradeA
+	found := false
+
+	for _, suites := range cipherSuites {
+		for _, suite := range suites {
+			found = true
+			grade := GradeCipherSuite(suite)
+			if gradeOrder[grade] > gradeOrder[worst] {
+				worst = grade
+			}
+		}
+	}
+
+	if !found {
+		return ""
+	}
+	return string(worst)
+}

--- a/pkg/tlscheck/ciphergrade_test.go
+++ b/pkg/tlscheck/ciphergrade_test.go
@@ -1,0 +1,148 @@
+package tlscheck
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestGradeCipherSuite(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected CipherGrade
+	}{
+		// Grade A: TLS 1.3 ciphers (AEAD, ephemeral key exchange)
+		{"TLS_AES_128_GCM_SHA256", GradeA},
+		{"TLS_AES_256_GCM_SHA384", GradeA},
+		{"TLS_CHACHA20_POLY1305_SHA256", GradeA},
+
+		// Grade A: ECDHE + AEAD
+		{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", GradeA},
+		{"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", GradeA},
+		{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", GradeA},
+		{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", GradeA},
+		{"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", GradeA},
+		{"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", GradeA},
+
+		// Grade B: ECDHE + CBC
+		{"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", GradeB},
+		{"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", GradeB},
+		{"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", GradeB},
+		{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", GradeB},
+		{"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", GradeB},
+		{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", GradeB},
+
+		// Grade C: RSA key exchange (no forward secrecy)
+		{"TLS_RSA_WITH_AES_128_GCM_SHA256", GradeC},
+		{"TLS_RSA_WITH_AES_256_GCM_SHA384", GradeC},
+		{"TLS_RSA_WITH_AES_128_CBC_SHA", GradeC},
+		{"TLS_RSA_WITH_AES_256_CBC_SHA", GradeC},
+		{"TLS_RSA_WITH_AES_128_CBC_SHA256", GradeC},
+
+		// Grade D: Weak ciphers (3DES, RC4)
+		{"TLS_RSA_WITH_3DES_EDE_CBC_SHA", GradeD},
+		{"TLS_RSA_WITH_RC4_128_SHA", GradeD},
+		{"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", GradeD},
+		{"TLS_ECDHE_RSA_WITH_RC4_128_SHA", GradeD},
+		{"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA", GradeD},
+
+		// Grade F: NULL/export ciphers
+		{"TLS_RSA_WITH_NULL_SHA", GradeF},
+		{"TLS_RSA_EXPORT_WITH_RC4_40_MD5", GradeF},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GradeCipherSuite(tt.name)
+			if got != tt.expected {
+				t.Errorf("GradeCipherSuite(%q) = %q, want %q", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAllGoCipherSuitesGraded(t *testing.T) {
+	allSuites := append(tls.CipherSuites(), tls.InsecureCipherSuites()...)
+	for _, suite := range allSuites {
+		grade := GradeCipherSuite(suite.Name)
+		if grade == "" {
+			t.Errorf("cipher suite %q (0x%04x) returned empty grade", suite.Name, suite.ID)
+		}
+	}
+}
+
+func TestGradeCipherSuites(t *testing.T) {
+	cipherSuites := map[string][]string{
+		"TLS 1.3": {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+		"TLS 1.2": {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA"},
+	}
+
+	grades := GradeCipherSuites(cipherSuites)
+
+	expected := map[string]string{
+		"TLS_AES_128_GCM_SHA256":                "A",
+		"TLS_AES_256_GCM_SHA384":                "A",
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256": "A",
+		"TLS_RSA_WITH_AES_128_CBC_SHA":          "C",
+	}
+
+	for cipher, expectedGrade := range expected {
+		if grade, ok := grades[cipher]; !ok {
+			t.Errorf("missing grade for cipher %q", cipher)
+		} else if grade != expectedGrade {
+			t.Errorf("GradeCipherSuites[%q] = %q, want %q", cipher, grade, expectedGrade)
+		}
+	}
+}
+
+func TestOverallGrade(t *testing.T) {
+	tests := []struct {
+		name         string
+		cipherSuites map[string][]string
+		expected     string
+	}{
+		{
+			name:         "empty",
+			cipherSuites: map[string][]string{},
+			expected:     "",
+		},
+		{
+			name: "all grade A",
+			cipherSuites: map[string][]string{
+				"TLS 1.3": {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+			},
+			expected: "A",
+		},
+		{
+			name: "mixed A and B",
+			cipherSuites: map[string][]string{
+				"TLS 1.2": {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"},
+			},
+			expected: "B",
+		},
+		{
+			name: "mixed A and C",
+			cipherSuites: map[string][]string{
+				"TLS 1.3": {"TLS_AES_128_GCM_SHA256"},
+				"TLS 1.2": {"TLS_RSA_WITH_AES_128_GCM_SHA256"},
+			},
+			expected: "C",
+		},
+		{
+			name: "includes weak cipher",
+			cipherSuites: map[string][]string{
+				"TLS 1.2": {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+				"TLS 1.0": {"TLS_RSA_WITH_3DES_EDE_CBC_SHA"},
+			},
+			expected: "D",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := OverallGrade(tt.cipherSuites)
+			if got != tt.expected {
+				t.Errorf("OverallGrade() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `pkg/tlscheck/ciphergrade.go` with cipher suite strength grading logic (A through F)
- Grades based on industry standards: A (AEAD+ECDHE/DHE), B (CBC+ECDHE/DHE), C (RSA key exchange), D (3DES/RC4), F (NULL/export)
- New CRD status fields: `cipherStrengthGrades` (per-cipher) and `overallCipherGrade` (worst grade)
- New `Grade` print column in `kubectl get tlsreport` output
- Controller automatically computes grades during TLS checks

## Test plan
- [x] All existing tests pass
- [x] New unit tests cover all grade classifications with specific cipher suites
- [x] `TestAllGoCipherSuitesGraded` verifies every Go cipher suite gets a grade
- [x] `TestOverallGrade` verifies worst-grade selection across mixed cipher sets
- [x] `TestGradeCipherSuites` verifies per-cipher grade map generation
- [x] Linter passes with 0 issues
- [x] CRD and DeepCopy regenerated

Closes #7

Generated with [Claude Code](https://claude.com/claude-code)