### PR TITLE
Add CSV and JUnit XML report export with kubectl plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
+.PHONY: build-plugin
+build-plugin: fmt vet ## Build kubectl-tlsreport plugin binary.
+	go build -o bin/kubectl-tlsreport ./cmd/kubectl-tlsreport
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go

--- a/cmd/kubectl-tlsreport/main.go
+++ b/cmd/kubectl-tlsreport/main.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+	"github.com/sebrandon1/tls-compliance-operator/pkg/export"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(securityv1alpha1.AddToScheme(scheme))
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	format := "csv"
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "csv", "junit":
+			format = os.Args[1]
+		case "--help", "-h":
+			printUsage()
+			return nil
+		default:
+			fmt.Fprintf(os.Stderr, "Unknown format: %s\n\n", os.Args[1])
+			printUsage()
+			return fmt.Errorf("unknown format: %s", os.Args[1])
+		}
+	}
+
+	// Build client from kubeconfig
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return fmt.Errorf("building kubeconfig: %w", err)
+	}
+
+	c, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("creating client: %w", err)
+	}
+
+	// List all TLSComplianceReports (cluster-scoped)
+	var reportList securityv1alpha1.TLSComplianceReportList
+	if err := c.List(context.Background(), &reportList); err != nil {
+		return fmt.Errorf("listing TLSComplianceReports: %w", err)
+	}
+
+	switch format {
+	case "csv":
+		return export.WriteCSV(os.Stdout, reportList.Items)
+	case "junit":
+		return export.WriteJUnit(os.Stdout, reportList.Items)
+	}
+
+	return nil
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, `Usage: kubectl tlsreport [FORMAT]
+
+Export TLS compliance reports from the cluster.
+
+Formats:
+  csv    Export as CSV (default)
+  junit  Export as JUnit XML
+
+Examples:
+  kubectl tlsreport csv > report.csv
+  kubectl tlsreport junit > report.xml
+`)
+}

--- a/pkg/export/csv.go
+++ b/pkg/export/csv.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+// CSVHeader is the header row for CSV exports.
+var CSVHeader = []string{
+	"Host", "Port", "Source", "Namespace", "Name",
+	"Compliance", "Grade",
+	"TLS1.3", "TLS1.2", "TLS1.1", "TLS1.0",
+	"QuantumReady",
+	"CertExpiry", "CertIssuer",
+}
+
+// WriteCSV writes TLSComplianceReport items as CSV to the given writer.
+func WriteCSV(w io.Writer, reports []securityv1alpha1.TLSComplianceReport) error {
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+
+	if err := cw.Write(CSVHeader); err != nil {
+		return fmt.Errorf("writing CSV header: %w", err)
+	}
+
+	for i := range reports {
+		row := reportToCSVRow(&reports[i])
+		if err := cw.Write(row); err != nil {
+			return fmt.Errorf("writing CSV row: %w", err)
+		}
+	}
+
+	return cw.Error()
+}
+
+func reportToCSVRow(r *securityv1alpha1.TLSComplianceReport) []string {
+	certExpiry := ""
+	certIssuer := ""
+	if r.Status.CertificateInfo != nil {
+		if r.Status.CertificateInfo.NotAfter != nil {
+			certExpiry = r.Status.CertificateInfo.NotAfter.Format("2006-01-02")
+		}
+		certIssuer = r.Status.CertificateInfo.Issuer
+	}
+
+	return []string{
+		r.Spec.Host,
+		strconv.Itoa(int(r.Spec.Port)),
+		string(r.Spec.SourceKind),
+		r.Spec.SourceNamespace,
+		r.Spec.SourceName,
+		string(r.Status.ComplianceStatus),
+		r.Status.OverallCipherGrade,
+		strconv.FormatBool(r.Status.TLSVersions.TLS13),
+		strconv.FormatBool(r.Status.TLSVersions.TLS12),
+		strconv.FormatBool(r.Status.TLSVersions.TLS11),
+		strconv.FormatBool(r.Status.TLSVersions.TLS10),
+		strconv.FormatBool(r.Status.QuantumReady),
+		certExpiry,
+		certIssuer,
+	}
+}

--- a/pkg/export/csv_test.go
+++ b/pkg/export/csv_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+func TestWriteCSV_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteCSV(&buf, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line (header only), got %d", len(lines))
+	}
+	if !strings.HasPrefix(lines[0], "Host,") {
+		t.Errorf("expected header to start with Host, got: %s", lines[0])
+	}
+}
+
+func TestWriteCSV_SingleReport(t *testing.T) {
+	expiry := metav1.NewTime(time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "my-service.default",
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "default",
+				SourceName:      "my-service",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus:   securityv1alpha1.ComplianceStatusCompliant,
+				OverallCipherGrade: "A",
+				TLSVersions: securityv1alpha1.TLSVersionSupport{
+					TLS13: true,
+					TLS12: true,
+				},
+				CertificateInfo: &securityv1alpha1.CertificateInfo{
+					NotAfter: &expiry,
+					Issuer:   "Let's Encrypt",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteCSV(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	data := lines[1]
+	expected := []string{
+		"my-service.default", "443", "Service", "default", "my-service",
+		"Compliant", "A",
+		"true", "true", "false", "false",
+		"false",
+		"2026-06-15", "Let's Encrypt",
+	}
+	for _, field := range expected {
+		if !strings.Contains(data, field) {
+			t.Errorf("expected CSV row to contain %q, got: %s", field, data)
+		}
+	}
+}
+
+func TestWriteCSV_NoCertificate(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "no-cert.example",
+				Port:            8080,
+				SourceKind:      securityv1alpha1.SourceKindIngress,
+				SourceNamespace: "test",
+				SourceName:      "no-cert",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusNoTLS,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteCSV(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	if !strings.Contains(lines[1], "NoTLS") {
+		t.Errorf("expected CSV to contain NoTLS status")
+	}
+}
+
+func TestWriteCSV_MultipleReports(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "svc1.ns1",
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "ns1",
+				SourceName:      "svc1",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "svc2.ns2",
+				Port:            8443,
+				SourceKind:      securityv1alpha1.SourceKindRoute,
+				SourceNamespace: "ns2",
+				SourceName:      "svc2",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusNonCompliant,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteCSV(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (header + 2 rows), got %d", len(lines))
+	}
+}

--- a/pkg/export/junit.go
+++ b/pkg/export/junit.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strconv"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+// JUnitTestSuites is the top-level JUnit XML element.
+type JUnitTestSuites struct {
+	XMLName    xml.Name         `xml:"testsuites"`
+	TestSuites []JUnitTestSuite `xml:"testsuite"`
+}
+
+// JUnitTestSuite represents a single test suite.
+type JUnitTestSuite struct {
+	XMLName   xml.Name        `xml:"testsuite"`
+	Name      string          `xml:"name,attr"`
+	Tests     int             `xml:"tests,attr"`
+	Failures  int             `xml:"failures,attr"`
+	TestCases []JUnitTestCase `xml:"testcase"`
+}
+
+// JUnitTestCase represents a single test case.
+type JUnitTestCase struct {
+	XMLName   xml.Name      `xml:"testcase"`
+	Name      string        `xml:"name,attr"`
+	ClassName string        `xml:"classname,attr"`
+	Failure   *JUnitFailure `xml:"failure,omitempty"`
+}
+
+// JUnitFailure represents a test failure.
+type JUnitFailure struct {
+	Message string `xml:"message,attr"`
+	Text    string `xml:",chardata"`
+}
+
+// WriteJUnit writes TLSComplianceReport items as JUnit XML to the given writer.
+func WriteJUnit(w io.Writer, reports []securityv1alpha1.TLSComplianceReport) error {
+	var failures int
+	cases := make([]JUnitTestCase, 0, len(reports))
+
+	for i := range reports {
+		tc := reportToTestCase(&reports[i])
+		if tc.Failure != nil {
+			failures++
+		}
+		cases = append(cases, tc)
+	}
+
+	suites := JUnitTestSuites{
+		TestSuites: []JUnitTestSuite{
+			{
+				Name:      "TLS Compliance",
+				Tests:     len(cases),
+				Failures:  failures,
+				TestCases: cases,
+			},
+		},
+	}
+
+	if _, err := fmt.Fprint(w, xml.Header); err != nil {
+		return fmt.Errorf("writing XML header: %w", err)
+	}
+
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(suites); err != nil {
+		return fmt.Errorf("encoding JUnit XML: %w", err)
+	}
+
+	return nil
+}
+
+func reportToTestCase(r *securityv1alpha1.TLSComplianceReport) JUnitTestCase {
+	name := r.Spec.Host + ":" + strconv.Itoa(int(r.Spec.Port))
+	tc := JUnitTestCase{
+		Name:      name,
+		ClassName: string(r.Spec.SourceKind),
+	}
+
+	switch r.Status.ComplianceStatus {
+	case securityv1alpha1.ComplianceStatusCompliant:
+		// pass — no failure
+	case securityv1alpha1.ComplianceStatusNonCompliant:
+		tc.Failure = &JUnitFailure{
+			Message: "NonCompliant: supports deprecated TLS versions",
+			Text:    failureDetail(r),
+		}
+	case securityv1alpha1.ComplianceStatusWarning:
+		tc.Failure = &JUnitFailure{
+			Message: "Warning: TLS 1.3 not supported",
+			Text:    failureDetail(r),
+		}
+	case securityv1alpha1.ComplianceStatusUnreachable,
+		securityv1alpha1.ComplianceStatusTimeout,
+		securityv1alpha1.ComplianceStatusClosed,
+		securityv1alpha1.ComplianceStatusFiltered:
+		tc.Failure = &JUnitFailure{
+			Message: string(r.Status.ComplianceStatus) + ": endpoint not reachable",
+			Text:    r.Status.LastError,
+		}
+	case securityv1alpha1.ComplianceStatusNoTLS:
+		tc.Failure = &JUnitFailure{
+			Message: "NoTLS: port does not speak TLS",
+		}
+	case securityv1alpha1.ComplianceStatusMutualTLSRequired:
+		tc.Failure = &JUnitFailure{
+			Message: "MutualTLSRequired: server requires client certificate",
+		}
+	default:
+		tc.Failure = &JUnitFailure{
+			Message: string(r.Status.ComplianceStatus) + ": check incomplete",
+		}
+	}
+
+	return tc
+}
+
+func failureDetail(r *securityv1alpha1.TLSComplianceReport) string {
+	detail := fmt.Sprintf("TLS 1.0=%v TLS 1.1=%v TLS 1.2=%v TLS 1.3=%v",
+		r.Status.TLSVersions.TLS10,
+		r.Status.TLSVersions.TLS11,
+		r.Status.TLSVersions.TLS12,
+		r.Status.TLSVersions.TLS13)
+	if r.Status.OverallCipherGrade != "" {
+		detail += " Grade=" + r.Status.OverallCipherGrade
+	}
+	return detail
+}

--- a/pkg/export/junit_test.go
+++ b/pkg/export/junit_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"bytes"
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+func TestWriteJUnit_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteJUnit(&buf, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var suites JUnitTestSuites
+	if err := xml.Unmarshal(buf.Bytes(), &suites); err != nil {
+		t.Fatalf("invalid XML: %v", err)
+	}
+	if len(suites.TestSuites) != 1 {
+		t.Fatalf("expected 1 suite, got %d", len(suites.TestSuites))
+	}
+	if suites.TestSuites[0].Tests != 0 {
+		t.Errorf("expected 0 tests, got %d", suites.TestSuites[0].Tests)
+	}
+}
+
+func TestWriteJUnit_CompliantPass(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "secure.example",
+				Port:       443,
+				SourceKind: securityv1alpha1.SourceKindService,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				TLSVersions: securityv1alpha1.TLSVersionSupport{
+					TLS13: true,
+					TLS12: true,
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteJUnit(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var suites JUnitTestSuites
+	if err := xml.Unmarshal(buf.Bytes(), &suites); err != nil {
+		t.Fatalf("invalid XML: %v", err)
+	}
+
+	suite := suites.TestSuites[0]
+	if suite.Tests != 1 {
+		t.Errorf("expected 1 test, got %d", suite.Tests)
+	}
+	if suite.Failures != 0 {
+		t.Errorf("expected 0 failures, got %d", suite.Failures)
+	}
+	if suite.TestCases[0].Failure != nil {
+		t.Error("expected no failure for compliant endpoint")
+	}
+	if suite.TestCases[0].Name != "secure.example:443" {
+		t.Errorf("unexpected test name: %s", suite.TestCases[0].Name)
+	}
+	if suite.TestCases[0].ClassName != "Service" {
+		t.Errorf("unexpected classname: %s", suite.TestCases[0].ClassName)
+	}
+}
+
+func TestWriteJUnit_NonCompliantFail(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "legacy.example",
+				Port:       8443,
+				SourceKind: securityv1alpha1.SourceKindService,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusNonCompliant,
+				TLSVersions: securityv1alpha1.TLSVersionSupport{
+					TLS10: true,
+					TLS11: true,
+				},
+				OverallCipherGrade: "D",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteJUnit(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var suites JUnitTestSuites
+	if err := xml.Unmarshal(buf.Bytes(), &suites); err != nil {
+		t.Fatalf("invalid XML: %v", err)
+	}
+
+	suite := suites.TestSuites[0]
+	if suite.Failures != 1 {
+		t.Errorf("expected 1 failure, got %d", suite.Failures)
+	}
+	tc := suite.TestCases[0]
+	if tc.Failure == nil {
+		t.Fatal("expected failure for non-compliant endpoint")
+	}
+	if !strings.Contains(tc.Failure.Message, "NonCompliant") {
+		t.Errorf("expected NonCompliant in failure message, got: %s", tc.Failure.Message)
+	}
+	if !strings.Contains(tc.Failure.Text, "Grade=D") {
+		t.Errorf("expected Grade=D in failure detail, got: %s", tc.Failure.Text)
+	}
+}
+
+func TestWriteJUnit_MixedResults(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "good.example",
+				Port:       443,
+				SourceKind: securityv1alpha1.SourceKindService,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "bad.example",
+				Port:       443,
+				SourceKind: securityv1alpha1.SourceKindIngress,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusNonCompliant,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "down.example",
+				Port:       443,
+				SourceKind: securityv1alpha1.SourceKindRoute,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusUnreachable,
+				LastError:        "connection refused",
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "notls.example",
+				Port:       80,
+				SourceKind: securityv1alpha1.SourceKindService,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusNoTLS,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteJUnit(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var suites JUnitTestSuites
+	if err := xml.Unmarshal(buf.Bytes(), &suites); err != nil {
+		t.Fatalf("invalid XML: %v", err)
+	}
+
+	suite := suites.TestSuites[0]
+	if suite.Tests != 4 {
+		t.Errorf("expected 4 tests, got %d", suite.Tests)
+	}
+	if suite.Failures != 3 {
+		t.Errorf("expected 3 failures, got %d", suite.Failures)
+	}
+
+	// Verify the compliant one passes
+	if suite.TestCases[0].Failure != nil {
+		t.Error("expected first test case to pass")
+	}
+	// Verify unreachable has error text
+	if suite.TestCases[2].Failure == nil {
+		t.Fatal("expected failure for unreachable endpoint")
+	}
+	if suite.TestCases[2].Failure.Text != "connection refused" {
+		t.Errorf("expected error text, got: %s", suite.TestCases[2].Failure.Text)
+	}
+}
+
+func TestWriteJUnit_AllStatusTypes(t *testing.T) {
+	statuses := []securityv1alpha1.ComplianceStatus{
+		securityv1alpha1.ComplianceStatusCompliant,
+		securityv1alpha1.ComplianceStatusNonCompliant,
+		securityv1alpha1.ComplianceStatusWarning,
+		securityv1alpha1.ComplianceStatusUnreachable,
+		securityv1alpha1.ComplianceStatusTimeout,
+		securityv1alpha1.ComplianceStatusClosed,
+		securityv1alpha1.ComplianceStatusFiltered,
+		securityv1alpha1.ComplianceStatusNoTLS,
+		securityv1alpha1.ComplianceStatusMutualTLSRequired,
+		securityv1alpha1.ComplianceStatusPending,
+		securityv1alpha1.ComplianceStatusUnknown,
+	}
+
+	reports := make([]securityv1alpha1.TLSComplianceReport, len(statuses))
+	for i, s := range statuses {
+		reports[i] = securityv1alpha1.TLSComplianceReport{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "test.example",
+				Port:       int32(443 + i),
+				SourceKind: securityv1alpha1.SourceKindService,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: s,
+			},
+		}
+	}
+
+	var buf bytes.Buffer
+	err := WriteJUnit(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var suites JUnitTestSuites
+	if err := xml.Unmarshal(buf.Bytes(), &suites); err != nil {
+		t.Fatalf("invalid XML: %v", err)
+	}
+
+	suite := suites.TestSuites[0]
+	if suite.Tests != len(statuses) {
+		t.Errorf("expected %d tests, got %d", len(statuses), suite.Tests)
+	}
+
+	// Only Compliant should pass
+	passCount := 0
+	for _, tc := range suite.TestCases {
+		if tc.Failure == nil {
+			passCount++
+		}
+	}
+	if passCount != 1 {
+		t.Errorf("expected exactly 1 passing test (Compliant), got %d", passCount)
+	}
+}
+
+func TestWriteJUnit_ValidXML(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "test.example",
+				Port:       443,
+				SourceKind: securityv1alpha1.SourceKindService,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteJUnit(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.HasPrefix(output, "<?xml") {
+		t.Error("expected XML declaration at start")
+	}
+	if !strings.Contains(output, `name="TLS Compliance"`) {
+		t.Error("expected test suite name")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `pkg/export` with CSV and JUnit XML formatters for TLSComplianceReport data
- CSV includes all key fields: host, port, source, compliance status, cipher grade, TLS versions, certificate info
- JUnit XML maps compliance status to pass/fail test cases for CI/CD integration
- Adds `cmd/kubectl-tlsreport` kubectl plugin that reads reports from the cluster and writes CSV or JUnit to stdout
- Adds `make build-plugin` Makefile target
- 91% test coverage on the export package

Closes #12

## Test plan
- [x] `make build` succeeds
- [x] `make build-plugin` succeeds
- [x] `make test` passes (10 new tests for export package)
- [x] `make lint` passes with 0 issues
- [ ] E2E tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)