### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add Dependabot to automatically open PRs for dependency updates across three ecosystems:
  - **Go modules** — weekly, up to 10 open PRs
  - **GitHub Actions** — weekly, up to 5 open PRs
  - **Docker** — weekly, up to 5 open PRs

## Test plan
- [x] YAML validates against Dependabot v2 schema
- [ ] Verify Dependabot opens PRs after merge (will appear within ~24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)