### PR TITLE
Add Dependabot grouping for Kubernetes dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      controller-runtime:
+        patterns:
+          - "sigs.k8s.io/controller-runtime"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
- Add Dependabot dependency groups so `k8s.io/*` and `sigs.k8s.io/*` updates are bundled into a single PR instead of one per module
- Prevents the current situation where a lockstep k8s release (e.g. 0.35.0 -> 0.35.1) creates 3+ separate PRs (#30, #31, #32)

## Test plan
- [x] YAML validates against Dependabot v2 schema
- [ ] After merge, close existing individual k8s PRs (#30, #31, #32) — Dependabot will re-open them as a single grouped PR on the next schedule run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
