### PR TITLE
Add Red Hat status pre-flight check

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -40,6 +40,12 @@ jobs:
       id-token: write  # Required for cosign keyless signing with GitHub OIDC
 
     steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            Quay.io
+
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -78,6 +78,13 @@ jobs:
     name: E2E Tests on OpenShift
     runs-on: ubuntu-latest
     steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            api.openshift.com
+            developers.redhat.com
+
       - name: Check for PULL_SECRET
         env:
           PULL_SECRET: ${{ secrets.PULL_SECRET }}


### PR DESCRIPTION
Add `palmsoftware/redhat-status@v0` as pre-flight check in workflows that depend on Red Hat infrastructure.