### PR TITLE
Add PQC compliance readiness classification

### DIFF
--- a/api/v1alpha1/tlscompliancereport_types.go
+++ b/api/v1alpha1/tlscompliancereport_types.go
@@ -61,6 +61,24 @@ const (
 	ComplianceStatusUnknown ComplianceStatus = "Unknown"
 )
 
+// PQCReadiness indicates the post-quantum cryptography readiness level of an endpoint.
+// Modeled after the classification used by the upstream OpenShift tls-scanner.
+// +kubebuilder:validation:Enum=PQCReady;TLS13Capable;LegacyTLS;NoPQC
+type PQCReadiness string
+
+const (
+	// PQCReadinessPQCReady means the endpoint supports TLS 1.3 with a post-quantum
+	// key exchange algorithm (e.g. X25519MLKEM768)
+	PQCReadinessPQCReady PQCReadiness = "PQCReady"
+	// PQCReadinessTLS13Capable means the endpoint supports TLS 1.3 but has not
+	// negotiated a post-quantum key exchange algorithm
+	PQCReadinessTLS13Capable PQCReadiness = "TLS13Capable"
+	// PQCReadinessLegacyTLS means the endpoint only supports TLS 1.2 or older
+	PQCReadinessLegacyTLS PQCReadiness = "LegacyTLS"
+	// PQCReadinessNoPQC means no TLS was detected on the endpoint
+	PQCReadinessNoPQC PQCReadiness = "NoPQC"
+)
+
 // TLSVersionSupport indicates which TLS versions an endpoint supports
 type TLSVersionSupport struct {
 	// TLS10 indicates if TLS 1.0 is supported
@@ -172,6 +190,12 @@ type TLSComplianceReportStatus struct {
 	// +optional
 	QuantumReady bool `json:"quantumReady"`
 
+	// PQCReadiness classifies the endpoint's post-quantum cryptography readiness:
+	// PQCReady (TLS 1.3 + ML-KEM), TLS13Capable (TLS 1.3 without ML-KEM),
+	// LegacyTLS (TLS 1.2 or older only), or NoPQC (no TLS detected)
+	// +optional
+	PQCReadiness PQCReadiness `json:"pqcReadiness,omitempty"`
+
 	// CertificateInfo contains details about the TLS certificate
 	// +optional
 	CertificateInfo *CertificateInfo `json:"certificateInfo,omitempty"`
@@ -241,7 +265,7 @@ type TLSComplianceReportStatus struct {
 // +kubebuilder:printcolumn:name="TLS1.3",type=boolean,JSONPath=`.status.tlsVersions.tls13`
 // +kubebuilder:printcolumn:name="TLS1.2",type=boolean,JSONPath=`.status.tlsVersions.tls12`
 // +kubebuilder:printcolumn:name="TLS1.0",type=boolean,JSONPath=`.status.tlsVersions.tls10`
-// +kubebuilder:printcolumn:name="PQC",type=boolean,JSONPath=`.status.quantumReady`
+// +kubebuilder:printcolumn:name="PQC",type=string,JSONPath=`.status.pqcReadiness`
 // +kubebuilder:printcolumn:name="CertExpiry",type=integer,JSONPath=`.status.certificateInfo.daysUntilExpiry`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
@@ -41,9 +41,9 @@ spec:
     - jsonPath: .status.tlsVersions.tls10
       name: TLS1.0
       type: boolean
-    - jsonPath: .status.quantumReady
+    - jsonPath: .status.pqcReadiness
       name: PQC
-      type: boolean
+      type: string
     - jsonPath: .status.certificateInfo.daysUntilExpiry
       name: CertExpiry
       type: integer
@@ -364,6 +364,17 @@ spec:
               overallCipherGrade:
                 description: OverallCipherGrade is the worst grade across all negotiated
                   cipher suites
+                type: string
+              pqcReadiness:
+                description: |-
+                  PQCReadiness classifies the endpoint's post-quantum cryptography readiness:
+                  PQCReady (TLS 1.3 + ML-KEM), TLS13Capable (TLS 1.3 without ML-KEM),
+                  LegacyTLS (TLS 1.2 or older only), or NoPQC (no TLS detected)
+                enum:
+                - PQCReady
+                - TLS13Capable
+                - LegacyTLS
+                - NoPQC
                 type: string
               quantumReady:
                 description: |-

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,9 +26,9 @@ The operator begins scanning immediately. Within a few minutes you'll see
 
 ```bash
 $ kubectl get tlsreport
-NAME                                                              HOST                                        PORT    SOURCE    COMPLIANCE   GRADE   TLS1.3   TLS1.2   TLS1.0   PQC     CERTEXPIRY   AGE
-kubernetes-default-443-d74c551f                                   kubernetes.default                           443     Service   Compliant    A       true     true     false    false   365d         5m
-console-openshift-console-apps-crc-testing-443-40b31eb3           console-openshift-console.apps-crc.testing   443     Route     Compliant    A       true     true     false    false   29d          5m
+NAME                                                              HOST                                        PORT    SOURCE    COMPLIANCE   GRADE   TLS1.3   TLS1.2   TLS1.0   PQC            CERTEXPIRY   AGE
+kubernetes-default-443-d74c551f                                   kubernetes.default                           443     Service   Compliant    A       true     true     false    TLS13Capable   365d         5m
+console-openshift-console-apps-crc-testing-443-40b31eb3           console-openshift-console.apps-crc.testing   443     Route     Compliant    A       true     true     false    TLS13Capable   29d          5m
 ```
 
 ## OpenShift Notes

--- a/docs/viewing-reports.md
+++ b/docs/viewing-reports.md
@@ -4,10 +4,10 @@
 
 ```bash
 $ kubectl get tlsreport
-NAME                                                           HOST                                                  PORT    SOURCE    COMPLIANCE   GRADE   TLS1.3   TLS1.2   TLS1.0   PQC     CERTEXPIRY   AGE
-rhcos4-moderate-master-rs-openshift-compliance-8443-03744f25   rhcos4-moderate-master-rs.openshift-compliance         8443    Service   Compliant    A       true     false    false    false   0            5m
-google-com-443-01d44386                                        google.com                                            443     Target    Compliant    B       true     true     true     true    53           2m
-ocp4-cis-rs-openshift-compliance-8443-aab74008                 ocp4-cis-rs.openshift-compliance                      8443    Service   Closed               false    false    false    false                6m
+NAME                                                           HOST                                                  PORT    SOURCE    COMPLIANCE   GRADE   TLS1.3   TLS1.2   TLS1.0   PQC            CERTEXPIRY   AGE
+rhcos4-moderate-master-rs-openshift-compliance-8443-03744f25   rhcos4-moderate-master-rs.openshift-compliance         8443    Service   Compliant    A       true     false    false    TLS13Capable   0            5m
+google-com-443-01d44386                                        google.com                                            443     Target    Compliant    B       true     true     true     PQCReady       53           2m
+ocp4-cis-rs-openshift-compliance-8443-aab74008                 ocp4-cis-rs.openshift-compliance                      8443    Service   Closed               false    false    false    NoPQC                       6m
 ```
 
 ### What the Columns Mean
@@ -17,7 +17,7 @@ ocp4-cis-rs-openshift-compliance-8443-aab74008                 ocp4-cis-rs.opens
 | **COMPLIANCE** | Overall status: Compliant, NonCompliant, Closed, Timeout, NoTLS, etc. |
 | **GRADE** | Cipher strength grade (A-F). A = strong ciphers only. |
 | **TLS1.3/1.2/1.0** | Whether each TLS version is supported. |
-| **PQC** | Post-quantum cryptography readiness (e.g. X25519MLKEM768). |
+| **PQC** | Post-quantum cryptography readiness: PQCReady (TLS 1.3 + ML-KEM), TLS13Capable (TLS 1.3 without ML-KEM), LegacyTLS (TLS 1.2 or older), NoPQC (no TLS). |
 | **CERTEXPIRY** | Days until certificate expiration. |
 | **SOURCE** | How the endpoint was discovered: Service, Ingress, Route, Pod, or Target. |
 
@@ -80,13 +80,14 @@ Certificate Info:
   Subject:     CN=*.google.com
 ```
 
-**Post-Quantum Readiness** — key exchange curves per TLS version:
+**Post-Quantum Readiness** — key exchange curves and PQC classification:
 
 ```
 Negotiated Curves:
   TLS 1.2:  X25519
   TLS 1.3:  X25519MLKEM768
-Quantum Ready:  true
+Quantum Ready:    true
+PQC Readiness:    PQCReady
 ```
 
 **OpenShift TLS Profile Compliance** (OpenShift clusters only):
@@ -104,6 +105,7 @@ API Server Profile Compliance:
 Conditions:
   Type: TLSCompliant      Status: True   Message: Endpoint supports modern TLS (1.2 or 1.3)
   Type: CertificateValid  Status: True   Message: TLS certificate is valid for 53 more days
+  Type: PQCCompliant      Status: True   Message: Endpoint supports TLS 1.3 with post-quantum key exchange (ML-KEM)
 ```
 
 ## Filtering Reports

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -60,6 +60,8 @@ const (
 	EventReasonCertificateExpired  = "CertificateExpired"
 	EventReasonEndpointDiscovered  = "EndpointDiscovered"
 	EventReasonRetryExhausted      = "RetryExhausted"
+	EventReasonPQCReady            = "PQCReady"
+	EventReasonPQCNotReady         = "PQCNotReady"
 )
 
 // EndpointReconciler reconciles Service, Ingress, and Route resources
@@ -375,6 +377,7 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 
 	// Store old status for change detection
 	oldComplianceStatus := cr.Status.ComplianceStatus
+	oldPQCReadiness := cr.Status.PQCReadiness
 
 	// Update TLS version support
 	cr.Status.TLSVersions = securityv1alpha1.TLSVersionSupport{
@@ -390,9 +393,11 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 	cr.Status.CipherStrengthGrades = cipherGrades
 	cr.Status.OverallCipherGrade = tlscheck.OverallGrade(result.CipherSuites, cipherGrades)
 
-	// Update negotiated curves and quantum readiness
+	// PQCReadiness supersedes QuantumReady with a richer classification;
+	// both are populated for backward compatibility.
 	cr.Status.NegotiatedCurves = result.NegotiatedCurves
-	cr.Status.QuantumReady = isQuantumReady(result.NegotiatedCurves)
+	cr.Status.PQCReadiness = determinePQCReadiness(result)
+	cr.Status.QuantumReady = cr.Status.PQCReadiness == securityv1alpha1.PQCReadinessPQCReady
 
 	// Update certificate info
 	if result.Certificate != nil {
@@ -425,6 +430,7 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 	metrics.RecordVersionSupport(host, portStr, "1.1", result.SupportsTLS11)
 	metrics.RecordVersionSupport(host, portStr, "1.2", result.SupportsTLS12)
 	metrics.RecordVersionSupport(host, portStr, "1.3", result.SupportsTLS13)
+	metrics.RecordPQCReadiness(host, portStr, cr.Status.PQCReadiness)
 
 	// Update conditions
 	r.updateConditions(&cr, complianceStatus, result)
@@ -435,7 +441,7 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 	}
 
 	// Emit events
-	r.emitComplianceEvents(&cr, oldComplianceStatus, result)
+	r.emitComplianceEvents(&cr, oldComplianceStatus, oldPQCReadiness, result)
 }
 
 // updateRetryStatus updates the CR with intermediate retry status information
@@ -485,6 +491,21 @@ func isQuantumReady(curves map[string]string) bool {
 		}
 	}
 	return false
+}
+
+// determinePQCReadiness classifies the post-quantum cryptography readiness of
+// an endpoint based on its TLS version support and negotiated key exchange curves.
+func determinePQCReadiness(result *tlscheck.TLSCheckResult) securityv1alpha1.PQCReadiness {
+	if !result.SupportsTLS10 && !result.SupportsTLS11 && !result.SupportsTLS12 && !result.SupportsTLS13 {
+		return securityv1alpha1.PQCReadinessNoPQC
+	}
+	if !result.SupportsTLS13 {
+		return securityv1alpha1.PQCReadinessLegacyTLS
+	}
+	if isQuantumReady(result.NegotiatedCurves) {
+		return securityv1alpha1.PQCReadinessPQCReady
+	}
+	return securityv1alpha1.PQCReadinessTLS13Capable
 }
 
 // checkProfileCompliance evaluates the endpoint against OpenShift TLS security
@@ -576,6 +597,33 @@ func (r *EndpointReconciler) updateConditions(cr *securityv1alpha1.TLSCompliance
 		setCondition(&cr.Status.Conditions, certCondition)
 	}
 
+	// PQC Compliant condition
+	pqcCondition := metav1.Condition{
+		Type:               "PQCCompliant",
+		LastTransitionTime: now,
+	}
+
+	switch cr.Status.PQCReadiness {
+	case securityv1alpha1.PQCReadinessPQCReady:
+		pqcCondition.Status = metav1.ConditionTrue
+		pqcCondition.Reason = "PQCReady"
+		pqcCondition.Message = "Endpoint supports TLS 1.3 with post-quantum key exchange (ML-KEM)"
+	case securityv1alpha1.PQCReadinessTLS13Capable:
+		pqcCondition.Status = metav1.ConditionFalse
+		pqcCondition.Reason = "TLS13Capable"
+		pqcCondition.Message = "Endpoint supports TLS 1.3 but has not negotiated a post-quantum key exchange"
+	case securityv1alpha1.PQCReadinessLegacyTLS:
+		pqcCondition.Status = metav1.ConditionFalse
+		pqcCondition.Reason = "LegacyTLS"
+		pqcCondition.Message = "Endpoint only supports TLS 1.2 or older, no path to post-quantum cryptography"
+	default:
+		pqcCondition.Status = metav1.ConditionUnknown
+		pqcCondition.Reason = "NoPQC"
+		pqcCondition.Message = "No TLS detected on endpoint"
+	}
+
+	setCondition(&cr.Status.Conditions, pqcCondition)
+
 	// TLS Profile Compliant condition (OpenShift only)
 	if r.ProfileFetcher != nil {
 		profileCondition := metav1.Condition{
@@ -620,7 +668,7 @@ func setCondition(conditions *[]metav1.Condition, condition metav1.Condition) {
 }
 
 // emitComplianceEvents emits Kubernetes events for compliance changes
-func (r *EndpointReconciler) emitComplianceEvents(cr *securityv1alpha1.TLSComplianceReport, oldStatus securityv1alpha1.ComplianceStatus, result *tlscheck.TLSCheckResult) {
+func (r *EndpointReconciler) emitComplianceEvents(cr *securityv1alpha1.TLSComplianceReport, oldStatus securityv1alpha1.ComplianceStatus, oldPQCReadiness securityv1alpha1.PQCReadiness, result *tlscheck.TLSCheckResult) {
 	if r.Recorder == nil {
 		return
 	}
@@ -636,6 +684,17 @@ func (r *EndpointReconciler) emitComplianceEvents(cr *securityv1alpha1.TLSCompli
 		oldStatus != securityv1alpha1.ComplianceStatusPending {
 		r.Recorder.Event(cr, corev1.EventTypeWarning, EventReasonComplianceChanged,
 			fmt.Sprintf("Compliance status changed from %s to %s for %s:%d", oldStatus, cr.Status.ComplianceStatus, cr.Spec.Host, cr.Spec.Port))
+	}
+
+	// PQC readiness changed
+	if oldPQCReadiness != "" && oldPQCReadiness != cr.Status.PQCReadiness {
+		if cr.Status.PQCReadiness == securityv1alpha1.PQCReadinessPQCReady {
+			r.Recorder.Event(cr, corev1.EventTypeNormal, EventReasonPQCReady,
+				fmt.Sprintf("Endpoint %s:%d is now post-quantum ready (TLS 1.3 + ML-KEM)", cr.Spec.Host, cr.Spec.Port))
+		} else {
+			r.Recorder.Event(cr, corev1.EventTypeWarning, EventReasonPQCNotReady,
+				fmt.Sprintf("PQC readiness changed from %s to %s for %s:%d", oldPQCReadiness, cr.Status.PQCReadiness, cr.Spec.Host, cr.Spec.Port))
+		}
 	}
 
 	// Certificate expiry warnings

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -671,6 +671,71 @@ func TestIsQuantumReady(t *testing.T) {
 	}
 }
 
+func TestDeterminePQCReadiness(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *tlscheck.TLSCheckResult
+		expected securityv1alpha1.PQCReadiness
+	}{
+		{
+			name: "PQCReady - TLS 1.3 with MLKEM",
+			result: &tlscheck.TLSCheckResult{
+				SupportsTLS13:    true,
+				SupportsTLS12:    true,
+				NegotiatedCurves: map[string]string{"TLS 1.3": "X25519MLKEM768", "TLS 1.2": "X25519"},
+			},
+			expected: securityv1alpha1.PQCReadinessPQCReady,
+		},
+		{
+			name: "TLS13Capable - TLS 1.3 without MLKEM",
+			result: &tlscheck.TLSCheckResult{
+				SupportsTLS13:    true,
+				SupportsTLS12:    true,
+				NegotiatedCurves: map[string]string{"TLS 1.3": "X25519", "TLS 1.2": "X25519"},
+			},
+			expected: securityv1alpha1.PQCReadinessTLS13Capable,
+		},
+		{
+			name: "LegacyTLS - TLS 1.2 only",
+			result: &tlscheck.TLSCheckResult{
+				SupportsTLS12:    true,
+				NegotiatedCurves: map[string]string{"TLS 1.2": "P-256"},
+			},
+			expected: securityv1alpha1.PQCReadinessLegacyTLS,
+		},
+		{
+			name: "LegacyTLS - TLS 1.0 and 1.1 only",
+			result: &tlscheck.TLSCheckResult{
+				SupportsTLS10: true,
+				SupportsTLS11: true,
+			},
+			expected: securityv1alpha1.PQCReadinessLegacyTLS,
+		},
+		{
+			name:     "NoPQC - no TLS detected",
+			result:   &tlscheck.TLSCheckResult{},
+			expected: securityv1alpha1.PQCReadinessNoPQC,
+		},
+		{
+			name: "PQCReady - TLS 1.3 only with MLKEM",
+			result: &tlscheck.TLSCheckResult{
+				SupportsTLS13:    true,
+				NegotiatedCurves: map[string]string{"TLS 1.3": "X25519MLKEM768"},
+			},
+			expected: securityv1alpha1.PQCReadinessPQCReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determinePQCReadiness(tt.result)
+			if got != tt.expected {
+				t.Errorf("determinePQCReadiness() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestEndpointReconciler_IsNamespaceFiltered_ExcludeMode(t *testing.T) {
 	r := &EndpointReconciler{
 		ExcludeNamespaces: map[string]bool{"kube-system": true, "openshift-monitoring": true},

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,6 +19,8 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
 )
 
 const (
@@ -67,6 +69,16 @@ var (
 		[]string{"host", "port", "version"},
 	)
 
+	// PQCReadiness tracks PQC readiness status per endpoint (1=current status, 0=not)
+	PQCReadiness = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "pqc_readiness",
+			Help:      "Post-quantum cryptography readiness (1=current status, 0=not)",
+		},
+		[]string{"host", "port", "readiness"},
+	)
+
 	// ReconcileTotal tracks reconciliation attempts
 	ReconcileTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -113,6 +125,7 @@ func init() {
 		CheckDurationSeconds,
 		CertificateExpiryDays,
 		VersionSupport,
+		PQCReadiness,
 		ReconcileTotal,
 		ScanCycleDurationSeconds,
 		CheckRetriesTotal,
@@ -142,6 +155,23 @@ func RecordVersionSupport(host, port, version string, supported bool) {
 		val = 1
 	}
 	VersionSupport.WithLabelValues(host, port, version).Set(val)
+}
+
+// RecordPQCReadiness records the PQC readiness status for an endpoint.
+// Sets the given readiness level to 1 and all others to 0.
+func RecordPQCReadiness(host, port string, readiness securityv1alpha1.PQCReadiness) {
+	for _, level := range []securityv1alpha1.PQCReadiness{
+		securityv1alpha1.PQCReadinessPQCReady,
+		securityv1alpha1.PQCReadinessTLS13Capable,
+		securityv1alpha1.PQCReadinessLegacyTLS,
+		securityv1alpha1.PQCReadinessNoPQC,
+	} {
+		val := float64(0)
+		if level == readiness {
+			val = 1
+		}
+		PQCReadiness.WithLabelValues(host, port, string(level)).Set(val)
+	}
 }
 
 // RecordScanCycleDuration records the duration of a full scan cycle

--- a/pkg/export/csv.go
+++ b/pkg/export/csv.go
@@ -30,7 +30,7 @@ var CSVHeader = []string{
 	"Host", "Port", "Source", "Namespace", "Name",
 	"Compliance", "Grade",
 	"TLS1.3", "TLS1.2", "TLS1.1", "TLS1.0",
-	"QuantumReady",
+	"QuantumReady", "PQCReadiness",
 	"CertExpiry", "CertIssuer",
 }
 
@@ -80,6 +80,7 @@ func reportToCSVRow(r *securityv1alpha1.TLSComplianceReport) []string {
 		strconv.FormatBool(r.Status.TLSVersions.TLS11),
 		strconv.FormatBool(r.Status.TLSVersions.TLS10),
 		strconv.FormatBool(r.Status.QuantumReady),
+		string(r.Status.PQCReadiness),
 		certExpiry,
 		certIssuer,
 	}

--- a/pkg/export/json.go
+++ b/pkg/export/json.go
@@ -39,6 +39,7 @@ type JSONReport struct {
 	TLS11        bool   `json:"tls11"`
 	TLS10        bool   `json:"tls10"`
 	QuantumReady bool   `json:"quantumReady"`
+	PQCReadiness string `json:"pqcReadiness"`
 	CertExpiry   string `json:"certExpiry"`
 	CertIssuer   string `json:"certIssuer"`
 }
@@ -75,6 +76,7 @@ func reportToJSON(r *securityv1alpha1.TLSComplianceReport) JSONReport {
 		TLS11:        r.Status.TLSVersions.TLS11,
 		TLS10:        r.Status.TLSVersions.TLS10,
 		QuantumReady: r.Status.QuantumReady,
+		PQCReadiness: string(r.Status.PQCReadiness),
 		CertExpiry:   certExpiry,
 		CertIssuer:   certIssuer,
 	}

--- a/pkg/export/summary.go
+++ b/pkg/export/summary.go
@@ -40,6 +40,14 @@ var knownStatuses = []securityv1alpha1.ComplianceStatus{
 	securityv1alpha1.ComplianceStatusUnknown,
 }
 
+// knownPQCReadiness defines the deterministic order for PQC readiness output.
+var knownPQCReadiness = []securityv1alpha1.PQCReadiness{
+	securityv1alpha1.PQCReadinessPQCReady,
+	securityv1alpha1.PQCReadinessTLS13Capable,
+	securityv1alpha1.PQCReadinessLegacyTLS,
+	securityv1alpha1.PQCReadinessNoPQC,
+}
+
 // knownSourceKinds defines the deterministic order for source kind output.
 var knownSourceKinds = []securityv1alpha1.SourceKind{
 	securityv1alpha1.SourceKindService,
@@ -54,7 +62,9 @@ type Summary struct {
 	Total             int
 	ByStatus          map[securityv1alpha1.ComplianceStatus]int
 	BySourceKind      map[securityv1alpha1.SourceKind]int
+	ByPQCReadiness    map[securityv1alpha1.PQCReadiness]int
 	CompliancePercent float64
+	PQCReadyPercent   float64
 	CertExpired       int
 	CertExpiring7d    int
 	CertExpiring30d   int
@@ -65,15 +75,19 @@ type Summary struct {
 // The now parameter is used for certificate expiry calculations.
 func ComputeSummary(reports []securityv1alpha1.TLSComplianceReport, now time.Time) Summary {
 	s := Summary{
-		Total:        len(reports),
-		ByStatus:     make(map[securityv1alpha1.ComplianceStatus]int),
-		BySourceKind: make(map[securityv1alpha1.SourceKind]int),
+		Total:          len(reports),
+		ByStatus:       make(map[securityv1alpha1.ComplianceStatus]int),
+		BySourceKind:   make(map[securityv1alpha1.SourceKind]int),
+		ByPQCReadiness: make(map[securityv1alpha1.PQCReadiness]int),
 	}
 
 	for i := range reports {
 		r := &reports[i]
 		s.ByStatus[r.Status.ComplianceStatus]++
 		s.BySourceKind[r.Spec.SourceKind]++
+		if r.Status.PQCReadiness != "" {
+			s.ByPQCReadiness[r.Status.PQCReadiness]++
+		}
 
 		if r.Status.CertificateInfo != nil && r.Status.CertificateInfo.NotAfter != nil {
 			expiry := r.Status.CertificateInfo.NotAfter.Time
@@ -95,6 +109,8 @@ func ComputeSummary(reports []securityv1alpha1.TLSComplianceReport, now time.Tim
 	if s.Total > 0 {
 		compliant := s.ByStatus[securityv1alpha1.ComplianceStatusCompliant]
 		s.CompliancePercent = float64(compliant) / float64(s.Total) * 100
+		pqcReady := s.ByPQCReadiness[securityv1alpha1.PQCReadinessPQCReady]
+		s.PQCReadyPercent = float64(pqcReady) / float64(s.Total) * 100
 	}
 
 	return s
@@ -140,6 +156,18 @@ func WriteSummary(w io.Writer, reports []securityv1alpha1.TLSComplianceReport) e
 		count := s.BySourceKind[kind]
 		if count > 0 {
 			ew.printf("  %s:\t%d\n", kind, count)
+		}
+	}
+
+	if len(s.ByPQCReadiness) > 0 {
+		ew.printf("\nPost-Quantum Cryptography Readiness\n")
+		ew.printf("------------------------------------\n")
+		ew.printf("PQC Ready Rate:\t%.1f%%\n", s.PQCReadyPercent)
+		for _, readiness := range knownPQCReadiness {
+			count := s.ByPQCReadiness[readiness]
+			if count > 0 {
+				ew.printf("  %s:\t%d\n", readiness, count)
+			}
 		}
 	}
 

--- a/pkg/export/summary_test.go
+++ b/pkg/export/summary_test.go
@@ -212,6 +212,57 @@ func TestComputeSummary_NoCertInfo(t *testing.T) {
 	}
 }
 
+func TestComputeSummary_PQCReadiness(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     securityv1alpha1.PQCReadinessPQCReady,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     securityv1alpha1.PQCReadinessTLS13Capable,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     securityv1alpha1.PQCReadinessLegacyTLS,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusNoTLS,
+				PQCReadiness:     securityv1alpha1.PQCReadinessNoPQC,
+			},
+		},
+	}
+
+	s := ComputeSummary(reports, time.Now())
+
+	if s.ByPQCReadiness[securityv1alpha1.PQCReadinessPQCReady] != 1 {
+		t.Errorf("expected 1 PQCReady, got %d", s.ByPQCReadiness[securityv1alpha1.PQCReadinessPQCReady])
+	}
+	if s.ByPQCReadiness[securityv1alpha1.PQCReadinessTLS13Capable] != 1 {
+		t.Errorf("expected 1 TLS13Capable, got %d", s.ByPQCReadiness[securityv1alpha1.PQCReadinessTLS13Capable])
+	}
+	if s.ByPQCReadiness[securityv1alpha1.PQCReadinessLegacyTLS] != 1 {
+		t.Errorf("expected 1 LegacyTLS, got %d", s.ByPQCReadiness[securityv1alpha1.PQCReadinessLegacyTLS])
+	}
+	if s.ByPQCReadiness[securityv1alpha1.PQCReadinessNoPQC] != 1 {
+		t.Errorf("expected 1 NoPQC, got %d", s.ByPQCReadiness[securityv1alpha1.PQCReadinessNoPQC])
+	}
+	if s.PQCReadyPercent != 25 {
+		t.Errorf("expected 25%% PQC ready, got %f", s.PQCReadyPercent)
+	}
+}
+
 func TestWriteSummary_Output(t *testing.T) {
 	reports := []securityv1alpha1.TLSComplianceReport{
 		{
@@ -251,6 +302,44 @@ func TestWriteSummary_Output(t *testing.T) {
 	}
 	if !strings.Contains(output, "Ingress:") {
 		t.Error("expected output to contain 'Ingress:'")
+	}
+}
+
+func TestWriteSummary_PQCSection(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     securityv1alpha1.PQCReadinessPQCReady,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     securityv1alpha1.PQCReadinessTLS13Capable,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteSummary(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Post-Quantum Cryptography Readiness") {
+		t.Error("expected output to contain PQC readiness section")
+	}
+	if !strings.Contains(output, "PQC Ready Rate:") {
+		t.Error("expected output to contain 'PQC Ready Rate:'")
+	}
+	if !strings.Contains(output, "PQCReady:") {
+		t.Error("expected output to contain 'PQCReady:'")
+	}
+	if !strings.Contains(output, "TLS13Capable:") {
+		t.Error("expected output to contain 'TLS13Capable:'")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a PQCReadiness enum field (PQCReady, TLS13Capable, LegacyTLS, NoPQC) to TLSComplianceReport status, matching the upstream OpenShift tls-scanner post-quantum compliance model
- Adds PQCCompliant Kubernetes condition, tls_compliance_pqc_readiness Prometheus metric, and PQCReady/PQCNotReady events on readiness changes
- Updates CSV, JSON, and summary exports with PQC readiness data and a PQC Ready Rate percentage
- Derives the existing QuantumReady boolean from the new enum for backward compatibility

## Test plan

- [x] make build succeeds
- [x] make lint -- zero issues
- [x] make test -- all unit tests pass
- [x] New TestDeterminePQCReadiness covers all 4 readiness levels (6 cases)
- [x] New TestComputeSummary_PQCReadiness validates summary aggregation and percentage
- [x] New TestWriteSummary_PQCSection validates PQC section in human-readable output
- [ ] CI checks pass