### PR TITLE
Add forward secrecy status to TLS compliance reports

### DIFF
--- a/api/v1alpha1/tlscompliancereport_types.go
+++ b/api/v1alpha1/tlscompliancereport_types.go
@@ -180,6 +180,11 @@ type TLSComplianceReportStatus struct {
 	// +optional
 	OverallCipherGrade string `json:"overallCipherGrade,omitempty"`
 
+	// ForwardSecrecy indicates whether all negotiated cipher suites use
+	// ephemeral key exchange (ECDHE/DHE), providing perfect forward secrecy
+	// +optional
+	ForwardSecrecy bool `json:"forwardSecrecy"`
+
 	// NegotiatedCurves maps TLS version to the negotiated key exchange curve
 	// (e.g. X25519, P-256, X25519MLKEM768)
 	// +optional
@@ -262,6 +267,7 @@ type TLSComplianceReportStatus struct {
 // +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.sourceKind`
 // +kubebuilder:printcolumn:name="Compliance",type=string,JSONPath=`.status.complianceStatus`
 // +kubebuilder:printcolumn:name="Grade",type=string,JSONPath=`.status.overallCipherGrade`
+// +kubebuilder:printcolumn:name="FS",type=boolean,JSONPath=`.status.forwardSecrecy`
 // +kubebuilder:printcolumn:name="TLS1.3",type=boolean,JSONPath=`.status.tlsVersions.tls13`
 // +kubebuilder:printcolumn:name="TLS1.2",type=boolean,JSONPath=`.status.tlsVersions.tls12`
 // +kubebuilder:printcolumn:name="TLS1.0",type=boolean,JSONPath=`.status.tlsVersions.tls10`

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.overallCipherGrade
       name: Grade
       type: string
+    - jsonPath: .status.forwardSecrecy
+      name: FS
+      type: boolean
     - jsonPath: .status.tlsVersions.tls13
       name: TLS1.3
       type: boolean
@@ -279,6 +282,11 @@ spec:
                 description: FirstSeenAt is when this endpoint was first discovered
                 format: date-time
                 type: string
+              forwardSecrecy:
+                description: |-
+                  ForwardSecrecy indicates whether all negotiated cipher suites use
+                  ephemeral key exchange (ECDHE/DHE), providing perfect forward secrecy
+                type: boolean
               ingressProfileCompliance:
                 description: |-
                   IngressProfileCompliance contains the compliance result against the

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -392,6 +392,7 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 	cipherGrades := tlscheck.GradeCipherSuites(result.CipherSuites)
 	cr.Status.CipherStrengthGrades = cipherGrades
 	cr.Status.OverallCipherGrade = tlscheck.OverallGrade(result.CipherSuites, cipherGrades)
+	cr.Status.ForwardSecrecy = tlscheck.AllCiphersHaveForwardSecrecy(result.CipherSuites)
 
 	// PQCReadiness supersedes QuantumReady with a richer classification;
 	// both are populated for backward compatibility.
@@ -430,6 +431,7 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 	metrics.RecordVersionSupport(host, portStr, "1.1", result.SupportsTLS11)
 	metrics.RecordVersionSupport(host, portStr, "1.2", result.SupportsTLS12)
 	metrics.RecordVersionSupport(host, portStr, "1.3", result.SupportsTLS13)
+	metrics.RecordForwardSecrecy(host, portStr, cr.Status.ForwardSecrecy)
 	metrics.RecordPQCReadiness(host, portStr, cr.Status.PQCReadiness)
 
 	// Update conditions

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -69,6 +69,16 @@ var (
 		[]string{"host", "port", "version"},
 	)
 
+	// ForwardSecrecy tracks whether all ciphers support forward secrecy per endpoint
+	ForwardSecrecy = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "forward_secrecy",
+			Help:      "Forward secrecy support (1=all ciphers use ephemeral key exchange, 0=not)",
+		},
+		[]string{"host", "port"},
+	)
+
 	// PQCReadiness tracks PQC readiness status per endpoint (1=current status, 0=not)
 	PQCReadiness = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -125,6 +135,7 @@ func init() {
 		CheckDurationSeconds,
 		CertificateExpiryDays,
 		VersionSupport,
+		ForwardSecrecy,
 		PQCReadiness,
 		ReconcileTotal,
 		ScanCycleDurationSeconds,
@@ -146,6 +157,15 @@ func RecordCheckDuration(durationSeconds float64) {
 // RecordCertExpiry records the days until certificate expiry
 func RecordCertExpiry(host, port string, days float64) {
 	CertificateExpiryDays.WithLabelValues(host, port).Set(days)
+}
+
+// RecordForwardSecrecy records whether all ciphers support forward secrecy
+func RecordForwardSecrecy(host, port string, supported bool) {
+	val := float64(0)
+	if supported {
+		val = 1
+	}
+	ForwardSecrecy.WithLabelValues(host, port).Set(val)
 }
 
 // RecordVersionSupport records whether a TLS version is supported

--- a/pkg/endpoint/resolver_test.go
+++ b/pkg/endpoint/resolver_test.go
@@ -23,8 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestExtractFromService_HTTPSPort(t *testing.T) {

--- a/pkg/export/csv.go
+++ b/pkg/export/csv.go
@@ -28,7 +28,7 @@ import (
 // CSVHeader is the header row for CSV exports.
 var CSVHeader = []string{
 	"Host", "Port", "Source", "Namespace", "Name",
-	"Compliance", "Grade",
+	"Compliance", "Grade", "ForwardSecrecy",
 	"TLS1.3", "TLS1.2", "TLS1.1", "TLS1.0",
 	"QuantumReady", "PQCReadiness",
 	"CertExpiry", "CertIssuer",
@@ -75,6 +75,7 @@ func reportToCSVRow(r *securityv1alpha1.TLSComplianceReport) []string {
 		r.Spec.SourceName,
 		string(r.Status.ComplianceStatus),
 		r.Status.OverallCipherGrade,
+		strconv.FormatBool(r.Status.ForwardSecrecy),
 		strconv.FormatBool(r.Status.TLSVersions.TLS13),
 		strconv.FormatBool(r.Status.TLSVersions.TLS12),
 		strconv.FormatBool(r.Status.TLSVersions.TLS11),

--- a/pkg/export/json.go
+++ b/pkg/export/json.go
@@ -27,21 +27,22 @@ import (
 
 // JSONReport is the JSON representation of a single TLS compliance report.
 type JSONReport struct {
-	Host         string `json:"host"`
-	Port         string `json:"port"`
-	Source       string `json:"source"`
-	Namespace    string `json:"namespace"`
-	Name         string `json:"name"`
-	Compliance   string `json:"compliance"`
-	Grade        string `json:"grade"`
-	TLS13        bool   `json:"tls13"`
-	TLS12        bool   `json:"tls12"`
-	TLS11        bool   `json:"tls11"`
-	TLS10        bool   `json:"tls10"`
-	QuantumReady bool   `json:"quantumReady"`
-	PQCReadiness string `json:"pqcReadiness"`
-	CertExpiry   string `json:"certExpiry"`
-	CertIssuer   string `json:"certIssuer"`
+	Host           string `json:"host"`
+	Port           string `json:"port"`
+	Source         string `json:"source"`
+	Namespace      string `json:"namespace"`
+	Name           string `json:"name"`
+	Compliance     string `json:"compliance"`
+	Grade          string `json:"grade"`
+	ForwardSecrecy bool   `json:"forwardSecrecy"`
+	TLS13          bool   `json:"tls13"`
+	TLS12          bool   `json:"tls12"`
+	TLS11          bool   `json:"tls11"`
+	TLS10          bool   `json:"tls10"`
+	QuantumReady   bool   `json:"quantumReady"`
+	PQCReadiness   string `json:"pqcReadiness"`
+	CertExpiry     string `json:"certExpiry"`
+	CertIssuer     string `json:"certIssuer"`
 }
 
 // WriteJSON writes TLSComplianceReport items as pretty-printed JSON to the given writer.
@@ -64,20 +65,21 @@ func reportToJSON(r *securityv1alpha1.TLSComplianceReport) JSONReport {
 	certExpiry, certIssuer := extractCertInfo(r)
 
 	return JSONReport{
-		Host:         r.Spec.Host,
-		Port:         strconv.Itoa(int(r.Spec.Port)),
-		Source:       string(r.Spec.SourceKind),
-		Namespace:    r.Spec.SourceNamespace,
-		Name:         r.Spec.SourceName,
-		Compliance:   string(r.Status.ComplianceStatus),
-		Grade:        r.Status.OverallCipherGrade,
-		TLS13:        r.Status.TLSVersions.TLS13,
-		TLS12:        r.Status.TLSVersions.TLS12,
-		TLS11:        r.Status.TLSVersions.TLS11,
-		TLS10:        r.Status.TLSVersions.TLS10,
-		QuantumReady: r.Status.QuantumReady,
-		PQCReadiness: string(r.Status.PQCReadiness),
-		CertExpiry:   certExpiry,
-		CertIssuer:   certIssuer,
+		Host:           r.Spec.Host,
+		Port:           strconv.Itoa(int(r.Spec.Port)),
+		Source:         string(r.Spec.SourceKind),
+		Namespace:      r.Spec.SourceNamespace,
+		Name:           r.Spec.SourceName,
+		Compliance:     string(r.Status.ComplianceStatus),
+		Grade:          r.Status.OverallCipherGrade,
+		ForwardSecrecy: r.Status.ForwardSecrecy,
+		TLS13:          r.Status.TLSVersions.TLS13,
+		TLS12:          r.Status.TLSVersions.TLS12,
+		TLS11:          r.Status.TLSVersions.TLS11,
+		TLS10:          r.Status.TLSVersions.TLS10,
+		QuantumReady:   r.Status.QuantumReady,
+		PQCReadiness:   string(r.Status.PQCReadiness),
+		CertExpiry:     certExpiry,
+		CertIssuer:     certIssuer,
 	}
 }

--- a/pkg/export/summary.go
+++ b/pkg/export/summary.go
@@ -59,16 +59,17 @@ var knownSourceKinds = []securityv1alpha1.SourceKind{
 
 // Summary holds aggregated statistics for a set of TLS compliance reports.
 type Summary struct {
-	Total             int
-	ByStatus          map[securityv1alpha1.ComplianceStatus]int
-	BySourceKind      map[securityv1alpha1.SourceKind]int
-	ByPQCReadiness    map[securityv1alpha1.PQCReadiness]int
-	CompliancePercent float64
-	PQCReadyPercent   float64
-	CertExpired       int
-	CertExpiring7d    int
-	CertExpiring30d   int
-	CertExpiring90d   int
+	Total               int
+	ByStatus            map[securityv1alpha1.ComplianceStatus]int
+	BySourceKind        map[securityv1alpha1.SourceKind]int
+	ByPQCReadiness      map[securityv1alpha1.PQCReadiness]int
+	ForwardSecrecyCount int
+	CompliancePercent   float64
+	PQCReadyPercent     float64
+	CertExpired         int
+	CertExpiring7d      int
+	CertExpiring30d     int
+	CertExpiring90d     int
 }
 
 // ComputeSummary calculates summary statistics from a slice of reports.
@@ -85,6 +86,9 @@ func ComputeSummary(reports []securityv1alpha1.TLSComplianceReport, now time.Tim
 		r := &reports[i]
 		s.ByStatus[r.Status.ComplianceStatus]++
 		s.BySourceKind[r.Spec.SourceKind]++
+		if r.Status.ForwardSecrecy {
+			s.ForwardSecrecyCount++
+		}
 		if r.Status.PQCReadiness != "" {
 			s.ByPQCReadiness[r.Status.PQCReadiness]++
 		}
@@ -139,7 +143,12 @@ func WriteSummary(w io.Writer, reports []securityv1alpha1.TLSComplianceReport) e
 	ew.printf("TLS Compliance Summary\n")
 	ew.printf("======================\n\n")
 	ew.printf("Total Endpoints:\t%d\n", s.Total)
-	ew.printf("Compliance Rate:\t%.1f%%\n\n", s.CompliancePercent)
+	ew.printf("Compliance Rate:\t%.1f%%\n", s.CompliancePercent)
+	if s.Total > 0 {
+		fsPct := float64(s.ForwardSecrecyCount) / float64(s.Total) * 100
+		ew.printf("Forward Secrecy:\t%d/%d (%.1f%%)\n", s.ForwardSecrecyCount, s.Total, fsPct)
+	}
+	ew.printf("\n")
 
 	ew.printf("Status Breakdown\n")
 	ew.printf("----------------\n")

--- a/pkg/export/summary.go
+++ b/pkg/export/summary.go
@@ -63,9 +63,10 @@ type Summary struct {
 	ByStatus            map[securityv1alpha1.ComplianceStatus]int
 	BySourceKind        map[securityv1alpha1.SourceKind]int
 	ByPQCReadiness      map[securityv1alpha1.PQCReadiness]int
-	ForwardSecrecyCount int
-	CompliancePercent   float64
-	PQCReadyPercent     float64
+	ForwardSecrecyCount   int
+	CompliancePercent     float64
+	ForwardSecrecyPercent float64
+	PQCReadyPercent       float64
 	CertExpired         int
 	CertExpiring7d      int
 	CertExpiring30d     int
@@ -113,6 +114,7 @@ func ComputeSummary(reports []securityv1alpha1.TLSComplianceReport, now time.Tim
 	if s.Total > 0 {
 		compliant := s.ByStatus[securityv1alpha1.ComplianceStatusCompliant]
 		s.CompliancePercent = float64(compliant) / float64(s.Total) * 100
+		s.ForwardSecrecyPercent = float64(s.ForwardSecrecyCount) / float64(s.Total) * 100
 		pqcReady := s.ByPQCReadiness[securityv1alpha1.PQCReadinessPQCReady]
 		s.PQCReadyPercent = float64(pqcReady) / float64(s.Total) * 100
 	}
@@ -145,8 +147,7 @@ func WriteSummary(w io.Writer, reports []securityv1alpha1.TLSComplianceReport) e
 	ew.printf("Total Endpoints:\t%d\n", s.Total)
 	ew.printf("Compliance Rate:\t%.1f%%\n", s.CompliancePercent)
 	if s.Total > 0 {
-		fsPct := float64(s.ForwardSecrecyCount) / float64(s.Total) * 100
-		ew.printf("Forward Secrecy:\t%d/%d (%.1f%%)\n", s.ForwardSecrecyCount, s.Total, fsPct)
+		ew.printf("Forward Secrecy:\t%d/%d (%.1f%%)\n", s.ForwardSecrecyCount, s.Total, s.ForwardSecrecyPercent)
 	}
 	ew.printf("\n")
 

--- a/pkg/tlscheck/ciphergrade.go
+++ b/pkg/tlscheck/ciphergrade.go
@@ -61,6 +61,31 @@ func GradeCipherSuite(name string) CipherGrade {
 	return GradeC
 }
 
+// CipherHasForwardSecrecy returns true if the IANA cipher suite name uses
+// ephemeral key exchange (ECDHE or DHE), or is a TLS 1.3 cipher (which
+// always uses ephemeral key exchange).
+func CipherHasForwardSecrecy(name string) bool {
+	if !strings.Contains(name, "_WITH_") {
+		return true
+	}
+	return strings.HasPrefix(name, "TLS_ECDHE_") || strings.HasPrefix(name, "TLS_DHE_")
+}
+
+// AllCiphersHaveForwardSecrecy returns true if every negotiated cipher suite
+// supports forward secrecy. Returns false if no ciphers were negotiated.
+func AllCiphersHaveForwardSecrecy(cipherSuites map[string][]string) bool {
+	found := false
+	for _, suites := range cipherSuites {
+		for _, suite := range suites {
+			found = true
+			if !CipherHasForwardSecrecy(suite) {
+				return false
+			}
+		}
+	}
+	return found
+}
+
 // GradeCipherSuites returns per-cipher grades for a map of TLS version to cipher suite names.
 func GradeCipherSuites(cipherSuites map[string][]string) map[string]string {
 	grades := make(map[string]string)

--- a/pkg/tlscheck/ciphergrade.go
+++ b/pkg/tlscheck/ciphergrade.go
@@ -39,13 +39,12 @@ func GradeCipherSuite(name string) CipherGrade {
 		return GradeD
 	}
 
+	hasEphemeral := CipherHasForwardSecrecy(name)
+
 	// TLS 1.3 ciphers are all Grade A (AEAD with ephemeral key exchange)
 	if !strings.Contains(name, "_WITH_") {
 		return GradeA
 	}
-
-	// Check for ephemeral key exchange (ECDHE or DHE)
-	hasEphemeral := strings.HasPrefix(name, "TLS_ECDHE_") || strings.HasPrefix(name, "TLS_DHE_")
 
 	// Check for AEAD cipher (GCM or CHACHA20_POLY1305)
 	isAEAD := strings.Contains(name, "GCM") || strings.Contains(name, "CHACHA20_POLY1305")

--- a/pkg/tlscheck/ciphergrade_test.go
+++ b/pkg/tlscheck/ciphergrade_test.go
@@ -70,6 +70,92 @@ func TestAllGoCipherSuitesGraded(t *testing.T) {
 	}
 }
 
+func TestCipherHasForwardSecrecy(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		// TLS 1.3 ciphers always have FS
+		{"TLS_AES_128_GCM_SHA256", true},
+		{"TLS_AES_256_GCM_SHA384", true},
+		{"TLS_CHACHA20_POLY1305_SHA256", true},
+		// ECDHE = forward secrecy
+		{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", true},
+		{"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", true},
+		{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", true},
+		{"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", true},
+		// DHE = forward secrecy
+		{"TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", true},
+		// RSA = no forward secrecy
+		{"TLS_RSA_WITH_AES_128_GCM_SHA256", false},
+		{"TLS_RSA_WITH_AES_128_CBC_SHA", false},
+		{"TLS_RSA_WITH_3DES_EDE_CBC_SHA", false},
+		// NULL/export = no forward secrecy
+		{"TLS_RSA_WITH_NULL_SHA", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CipherHasForwardSecrecy(tt.name)
+			if got != tt.expected {
+				t.Errorf("CipherHasForwardSecrecy(%q) = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAllCiphersHaveForwardSecrecy(t *testing.T) {
+	tests := []struct {
+		name         string
+		cipherSuites map[string][]string
+		expected     bool
+	}{
+		{
+			name:         "empty",
+			cipherSuites: map[string][]string{},
+			expected:     false,
+		},
+		{
+			name: "all TLS 1.3",
+			cipherSuites: map[string][]string{
+				"TLS 1.3": {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+			},
+			expected: true,
+		},
+		{
+			name: "all ECDHE",
+			cipherSuites: map[string][]string{
+				"TLS 1.2": {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"},
+			},
+			expected: true,
+		},
+		{
+			name: "mixed ECDHE and RSA",
+			cipherSuites: map[string][]string{
+				"TLS 1.3": {"TLS_AES_128_GCM_SHA256"},
+				"TLS 1.2": {"TLS_RSA_WITH_AES_128_GCM_SHA256"},
+			},
+			expected: false,
+		},
+		{
+			name: "RSA only",
+			cipherSuites: map[string][]string{
+				"TLS 1.2": {"TLS_RSA_WITH_AES_128_CBC_SHA"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AllCiphersHaveForwardSecrecy(tt.cipherSuites)
+			if got != tt.expected {
+				t.Errorf("AllCiphersHaveForwardSecrecy() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestGradeCipherSuites(t *testing.T) {
 	cipherSuites := map[string][]string{
 		"TLS 1.3": {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},


### PR DESCRIPTION
## Summary

- Adds ForwardSecrecy bool field to TLSComplianceReport status, indicating whether all negotiated cipher suites use ephemeral key exchange (ECDHE/DHE)
- Adds CipherHasForwardSecrecy and AllCiphersHaveForwardSecrecy helpers in pkg/tlscheck
- Adds FS printer column to kubectl get tlsreport output
- Adds tls_compliance_forward_secrecy Prometheus metric
- Includes ForwardSecrecy in CSV, JSON, and summary exports with aggregate stats
- Matches upstream OpenShift tls-scanner forward secrecy reporting

## Test plan

- [x] make build succeeds
- [x] make lint -- zero issues
- [x] All unit tests pass
- [x] 18 new test cases for cipher forward secrecy classification
- [ ] CI checks pass