### PR TITLE
Add key exchange type details to TLS compliance reports

### DIFF
--- a/api/v1alpha1/tlscompliancereport_types.go
+++ b/api/v1alpha1/tlscompliancereport_types.go
@@ -185,6 +185,11 @@ type TLSComplianceReportStatus struct {
 	// +optional
 	ForwardSecrecy bool `json:"forwardSecrecy"`
 
+	// KeyExchangeTypes maps TLS version to the key exchange algorithm used
+	// (ECDHE, DHE, RSA, or TLS13)
+	// +optional
+	KeyExchangeTypes map[string]string `json:"keyExchangeTypes,omitempty"`
+
 	// NegotiatedCurves maps TLS version to the negotiated key exchange curve
 	// (e.g. X25519, P-256, X25519MLKEM768)
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -154,6 +154,13 @@ func (in *TLSComplianceReportStatus) DeepCopyInto(out *TLSComplianceReportStatus
 			(*out)[key] = val
 		}
 	}
+	if in.KeyExchangeTypes != nil {
+		in, out := &in.KeyExchangeTypes, &out.KeyExchangeTypes
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NegotiatedCurves != nil {
 		in, out := &in.NegotiatedCurves, &out.NegotiatedCurves
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
@@ -317,6 +317,13 @@ spec:
                 - minTLSVersionMet
                 - profileType
                 type: object
+              keyExchangeTypes:
+                additionalProperties:
+                  type: string
+                description: |-
+                  KeyExchangeTypes maps TLS version to the key exchange algorithm used
+                  (ECDHE, DHE, RSA, or TLS13)
+                type: object
               kubeletProfileCompliance:
                 description: |-
                   KubeletProfileCompliance contains the compliance result against the

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -394,6 +394,8 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 	cr.Status.OverallCipherGrade = tlscheck.OverallGrade(result.CipherSuites, cipherGrades)
 	cr.Status.ForwardSecrecy = tlscheck.AllCiphersHaveForwardSecrecy(result.CipherSuites)
 
+	cr.Status.KeyExchangeTypes = tlscheck.KeyExchangeTypes(result.CipherSuites)
+
 	// PQCReadiness supersedes QuantumReady with a richer classification;
 	// both are populated for backward compatibility.
 	cr.Status.NegotiatedCurves = result.NegotiatedCurves

--- a/pkg/export/csv.go
+++ b/pkg/export/csv.go
@@ -67,14 +67,16 @@ func extractCertInfo(r *securityv1alpha1.TLSComplianceReport) (certExpiry, certI
 }
 
 // formatKeyExchangeTypes returns a compact string of unique key exchange types
-// sorted alphabetically (e.g. "ECDHE,TLS13").
+// across all TLS versions, sorted alphabetically (e.g. "ECDHE,TLS13").
 func formatKeyExchangeTypes(keTypes map[string]string) string {
 	if len(keTypes) == 0 {
 		return ""
 	}
 	seen := make(map[string]bool)
 	for _, ke := range keTypes {
-		seen[ke] = true
+		for _, part := range strings.Split(ke, ",") {
+			seen[part] = true
+		}
 	}
 	unique := make([]string, 0, len(seen))
 	for ke := range seen {

--- a/pkg/export/csv.go
+++ b/pkg/export/csv.go
@@ -20,7 +20,9 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
+	"strings"
 
 	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
 )
@@ -28,7 +30,7 @@ import (
 // CSVHeader is the header row for CSV exports.
 var CSVHeader = []string{
 	"Host", "Port", "Source", "Namespace", "Name",
-	"Compliance", "Grade", "ForwardSecrecy",
+	"Compliance", "Grade", "ForwardSecrecy", "KeyExchange",
 	"TLS1.3", "TLS1.2", "TLS1.1", "TLS1.0",
 	"QuantumReady", "PQCReadiness",
 	"CertExpiry", "CertIssuer",
@@ -64,6 +66,24 @@ func extractCertInfo(r *securityv1alpha1.TLSComplianceReport) (certExpiry, certI
 	return
 }
 
+// formatKeyExchangeTypes returns a compact string of unique key exchange types
+// sorted alphabetically (e.g. "ECDHE,TLS13").
+func formatKeyExchangeTypes(keTypes map[string]string) string {
+	if len(keTypes) == 0 {
+		return ""
+	}
+	seen := make(map[string]bool)
+	for _, ke := range keTypes {
+		seen[ke] = true
+	}
+	unique := make([]string, 0, len(seen))
+	for ke := range seen {
+		unique = append(unique, ke)
+	}
+	sort.Strings(unique)
+	return strings.Join(unique, ",")
+}
+
 func reportToCSVRow(r *securityv1alpha1.TLSComplianceReport) []string {
 	certExpiry, certIssuer := extractCertInfo(r)
 
@@ -76,6 +96,7 @@ func reportToCSVRow(r *securityv1alpha1.TLSComplianceReport) []string {
 		string(r.Status.ComplianceStatus),
 		r.Status.OverallCipherGrade,
 		strconv.FormatBool(r.Status.ForwardSecrecy),
+		formatKeyExchangeTypes(r.Status.KeyExchangeTypes),
 		strconv.FormatBool(r.Status.TLSVersions.TLS13),
 		strconv.FormatBool(r.Status.TLSVersions.TLS12),
 		strconv.FormatBool(r.Status.TLSVersions.TLS11),

--- a/pkg/export/json.go
+++ b/pkg/export/json.go
@@ -27,22 +27,23 @@ import (
 
 // JSONReport is the JSON representation of a single TLS compliance report.
 type JSONReport struct {
-	Host           string `json:"host"`
-	Port           string `json:"port"`
-	Source         string `json:"source"`
-	Namespace      string `json:"namespace"`
-	Name           string `json:"name"`
-	Compliance     string `json:"compliance"`
-	Grade          string `json:"grade"`
-	ForwardSecrecy bool   `json:"forwardSecrecy"`
-	TLS13          bool   `json:"tls13"`
-	TLS12          bool   `json:"tls12"`
-	TLS11          bool   `json:"tls11"`
-	TLS10          bool   `json:"tls10"`
-	QuantumReady   bool   `json:"quantumReady"`
-	PQCReadiness   string `json:"pqcReadiness"`
-	CertExpiry     string `json:"certExpiry"`
-	CertIssuer     string `json:"certIssuer"`
+	Host             string            `json:"host"`
+	Port             string            `json:"port"`
+	Source           string            `json:"source"`
+	Namespace        string            `json:"namespace"`
+	Name             string            `json:"name"`
+	Compliance       string            `json:"compliance"`
+	Grade            string            `json:"grade"`
+	ForwardSecrecy   bool              `json:"forwardSecrecy"`
+	KeyExchangeTypes map[string]string `json:"keyExchangeTypes,omitempty"`
+	TLS13            bool              `json:"tls13"`
+	TLS12            bool              `json:"tls12"`
+	TLS11            bool              `json:"tls11"`
+	TLS10            bool              `json:"tls10"`
+	QuantumReady     bool              `json:"quantumReady"`
+	PQCReadiness     string            `json:"pqcReadiness"`
+	CertExpiry       string            `json:"certExpiry"`
+	CertIssuer       string            `json:"certIssuer"`
 }
 
 // WriteJSON writes TLSComplianceReport items as pretty-printed JSON to the given writer.
@@ -65,21 +66,22 @@ func reportToJSON(r *securityv1alpha1.TLSComplianceReport) JSONReport {
 	certExpiry, certIssuer := extractCertInfo(r)
 
 	return JSONReport{
-		Host:           r.Spec.Host,
-		Port:           strconv.Itoa(int(r.Spec.Port)),
-		Source:         string(r.Spec.SourceKind),
-		Namespace:      r.Spec.SourceNamespace,
-		Name:           r.Spec.SourceName,
-		Compliance:     string(r.Status.ComplianceStatus),
-		Grade:          r.Status.OverallCipherGrade,
-		ForwardSecrecy: r.Status.ForwardSecrecy,
-		TLS13:          r.Status.TLSVersions.TLS13,
-		TLS12:          r.Status.TLSVersions.TLS12,
-		TLS11:          r.Status.TLSVersions.TLS11,
-		TLS10:          r.Status.TLSVersions.TLS10,
-		QuantumReady:   r.Status.QuantumReady,
-		PQCReadiness:   string(r.Status.PQCReadiness),
-		CertExpiry:     certExpiry,
-		CertIssuer:     certIssuer,
+		Host:             r.Spec.Host,
+		Port:             strconv.Itoa(int(r.Spec.Port)),
+		Source:           string(r.Spec.SourceKind),
+		Namespace:        r.Spec.SourceNamespace,
+		Name:             r.Spec.SourceName,
+		Compliance:       string(r.Status.ComplianceStatus),
+		Grade:            r.Status.OverallCipherGrade,
+		ForwardSecrecy:   r.Status.ForwardSecrecy,
+		KeyExchangeTypes: r.Status.KeyExchangeTypes,
+		TLS13:            r.Status.TLSVersions.TLS13,
+		TLS12:            r.Status.TLSVersions.TLS12,
+		TLS11:            r.Status.TLSVersions.TLS11,
+		TLS10:            r.Status.TLSVersions.TLS10,
+		QuantumReady:     r.Status.QuantumReady,
+		PQCReadiness:     string(r.Status.PQCReadiness),
+		CertExpiry:       certExpiry,
+		CertIssuer:       certIssuer,
 	}
 }

--- a/pkg/export/summary.go
+++ b/pkg/export/summary.go
@@ -59,18 +59,18 @@ var knownSourceKinds = []securityv1alpha1.SourceKind{
 
 // Summary holds aggregated statistics for a set of TLS compliance reports.
 type Summary struct {
-	Total               int
-	ByStatus            map[securityv1alpha1.ComplianceStatus]int
-	BySourceKind        map[securityv1alpha1.SourceKind]int
-	ByPQCReadiness      map[securityv1alpha1.PQCReadiness]int
+	Total                 int
+	ByStatus              map[securityv1alpha1.ComplianceStatus]int
+	BySourceKind          map[securityv1alpha1.SourceKind]int
+	ByPQCReadiness        map[securityv1alpha1.PQCReadiness]int
 	ForwardSecrecyCount   int
 	CompliancePercent     float64
 	ForwardSecrecyPercent float64
 	PQCReadyPercent       float64
-	CertExpired         int
-	CertExpiring7d      int
-	CertExpiring30d     int
-	CertExpiring90d     int
+	CertExpired           int
+	CertExpiring7d        int
+	CertExpiring30d       int
+	CertExpiring90d       int
 }
 
 // ComputeSummary calculates summary statistics from a slice of reports.

--- a/pkg/tlscheck/ciphergrade.go
+++ b/pkg/tlscheck/ciphergrade.go
@@ -1,6 +1,9 @@
 package tlscheck
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // CipherGrade represents the strength grade of a cipher suite.
 type CipherGrade string
@@ -64,10 +67,7 @@ func GradeCipherSuite(name string) CipherGrade {
 // ephemeral key exchange (ECDHE or DHE), or is a TLS 1.3 cipher (which
 // always uses ephemeral key exchange).
 func CipherHasForwardSecrecy(name string) bool {
-	if !strings.Contains(name, "_WITH_") {
-		return true
-	}
-	return strings.HasPrefix(name, "TLS_ECDHE_") || strings.HasPrefix(name, "TLS_DHE_")
+	return KeyExchangeType(name) != "RSA"
 }
 
 // AllCiphersHaveForwardSecrecy returns true if every negotiated cipher suite
@@ -100,12 +100,24 @@ func KeyExchangeType(name string) string {
 	return "RSA"
 }
 
-// KeyExchangeTypes returns the key exchange type used per TLS version.
+// KeyExchangeTypes returns the key exchange types used per TLS version.
+// If multiple cipher suites use different key exchange algorithms for the
+// same version, all distinct types are included (e.g. "ECDHE,RSA").
 func KeyExchangeTypes(cipherSuites map[string][]string) map[string]string {
 	result := make(map[string]string, len(cipherSuites))
 	for version, suites := range cipherSuites {
-		if len(suites) > 0 {
-			result[version] = KeyExchangeType(suites[0])
+		seen := make(map[string]bool)
+		var types []string
+		for _, suite := range suites {
+			ke := KeyExchangeType(suite)
+			if !seen[ke] {
+				seen[ke] = true
+				types = append(types, ke)
+			}
+		}
+		if len(types) > 0 {
+			sort.Strings(types)
+			result[version] = strings.Join(types, ",")
 		}
 	}
 	return result

--- a/pkg/tlscheck/ciphergrade.go
+++ b/pkg/tlscheck/ciphergrade.go
@@ -85,6 +85,32 @@ func AllCiphersHaveForwardSecrecy(cipherSuites map[string][]string) bool {
 	return found
 }
 
+// KeyExchangeType extracts the key exchange algorithm from an IANA cipher suite name.
+// Returns "ECDHE", "DHE", "RSA", or "TLS13" (TLS 1.3 uses implicit ephemeral exchange).
+func KeyExchangeType(name string) string {
+	if !strings.Contains(name, "_WITH_") {
+		return "TLS13"
+	}
+	if strings.HasPrefix(name, "TLS_ECDHE_") {
+		return "ECDHE"
+	}
+	if strings.HasPrefix(name, "TLS_DHE_") {
+		return "DHE"
+	}
+	return "RSA"
+}
+
+// KeyExchangeTypes returns the key exchange type used per TLS version.
+func KeyExchangeTypes(cipherSuites map[string][]string) map[string]string {
+	result := make(map[string]string, len(cipherSuites))
+	for version, suites := range cipherSuites {
+		if len(suites) > 0 {
+			result[version] = KeyExchangeType(suites[0])
+		}
+	}
+	return result
+}
+
 // GradeCipherSuites returns per-cipher grades for a map of TLS version to cipher suite names.
 func GradeCipherSuites(cipherSuites map[string][]string) map[string]string {
 	grades := make(map[string]string)

--- a/pkg/tlscheck/ciphergrade_test.go
+++ b/pkg/tlscheck/ciphergrade_test.go
@@ -136,26 +136,54 @@ func TestKeyExchangeType(t *testing.T) {
 }
 
 func TestKeyExchangeTypes(t *testing.T) {
-	cipherSuites := map[string][]string{
-		"TLS 1.3": {"TLS_AES_128_GCM_SHA256"},
-		"TLS 1.2": {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
-		"TLS 1.0": {"TLS_RSA_WITH_AES_128_CBC_SHA"},
+	tests := []struct {
+		name         string
+		cipherSuites map[string][]string
+		expected     map[string]string
+	}{
+		{
+			name: "single cipher per version",
+			cipherSuites: map[string][]string{
+				"TLS 1.3": {"TLS_AES_128_GCM_SHA256"},
+				"TLS 1.2": {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+				"TLS 1.0": {"TLS_RSA_WITH_AES_128_CBC_SHA"},
+			},
+			expected: map[string]string{
+				"TLS 1.3": "TLS13",
+				"TLS 1.2": "ECDHE",
+				"TLS 1.0": "RSA",
+			},
+		},
+		{
+			name: "mixed key exchange in same version",
+			cipherSuites: map[string][]string{
+				"TLS 1.2": {
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					"TLS_RSA_WITH_AES_128_CBC_SHA",
+				},
+			},
+			expected: map[string]string{
+				"TLS 1.2": "ECDHE,RSA",
+			},
+		},
+		{
+			name:         "empty",
+			cipherSuites: map[string][]string{},
+			expected:     map[string]string{},
+		},
 	}
 
-	result := KeyExchangeTypes(cipherSuites)
-
-	expected := map[string]string{
-		"TLS 1.3": "TLS13",
-		"TLS 1.2": "ECDHE",
-		"TLS 1.0": "RSA",
-	}
-
-	for version, expectedKE := range expected {
-		if got, ok := result[version]; !ok {
-			t.Errorf("missing key exchange for %q", version)
-		} else if got != expectedKE {
-			t.Errorf("KeyExchangeTypes[%q] = %q, want %q", version, got, expectedKE)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := KeyExchangeTypes(tt.cipherSuites)
+			for version, expectedKE := range tt.expected {
+				if got, ok := result[version]; !ok {
+					t.Errorf("missing key exchange for %q", version)
+				} else if got != expectedKE {
+					t.Errorf("KeyExchangeTypes[%q] = %q, want %q", version, got, expectedKE)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/tlscheck/ciphergrade_test.go
+++ b/pkg/tlscheck/ciphergrade_test.go
@@ -104,6 +104,61 @@ func TestCipherHasForwardSecrecy(t *testing.T) {
 	}
 }
 
+func TestKeyExchangeType(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		// TLS 1.3
+		{"TLS_AES_128_GCM_SHA256", "TLS13"},
+		{"TLS_AES_256_GCM_SHA384", "TLS13"},
+		{"TLS_CHACHA20_POLY1305_SHA256", "TLS13"},
+		// ECDHE
+		{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "ECDHE"},
+		{"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "ECDHE"},
+		{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "ECDHE"},
+		// DHE
+		{"TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", "DHE"},
+		// RSA
+		{"TLS_RSA_WITH_AES_128_GCM_SHA256", "RSA"},
+		{"TLS_RSA_WITH_AES_128_CBC_SHA", "RSA"},
+		{"TLS_RSA_WITH_3DES_EDE_CBC_SHA", "RSA"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := KeyExchangeType(tt.name)
+			if got != tt.expected {
+				t.Errorf("KeyExchangeType(%q) = %q, want %q", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKeyExchangeTypes(t *testing.T) {
+	cipherSuites := map[string][]string{
+		"TLS 1.3": {"TLS_AES_128_GCM_SHA256"},
+		"TLS 1.2": {"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+		"TLS 1.0": {"TLS_RSA_WITH_AES_128_CBC_SHA"},
+	}
+
+	result := KeyExchangeTypes(cipherSuites)
+
+	expected := map[string]string{
+		"TLS 1.3": "TLS13",
+		"TLS 1.2": "ECDHE",
+		"TLS 1.0": "RSA",
+	}
+
+	for version, expectedKE := range expected {
+		if got, ok := result[version]; !ok {
+			t.Errorf("missing key exchange for %q", version)
+		} else if got != expectedKE {
+			t.Errorf("KeyExchangeTypes[%q] = %q, want %q", version, got, expectedKE)
+		}
+	}
+}
+
 func TestAllCiphersHaveForwardSecrecy(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

- Extracts key exchange algorithm (ECDHE, DHE, RSA, TLS13) per TLS version from cipher suite names
- Adds KeyExchangeTypes map field to TLSComplianceReport status
- Includes key exchange in CSV (compact format) and JSON exports
- Complements the forward secrecy and PQC readiness features with explicit key exchange visibility

## Test plan

- [x] make build succeeds
- [x] make lint -- zero issues
- [x] All unit tests pass
- [x] New tests for KeyExchangeType (10 cases) and KeyExchangeTypes (3 versions)
- [ ] CI checks pass