### PR TITLE
Add IPv6 and dual-stack support

### DIFF
--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -248,7 +249,7 @@ func (r *EndpointReconciler) processEndpoint(ctx context.Context, ep endpoint.En
 					Status:             metav1.ConditionTrue,
 					LastTransitionTime: now,
 					Reason:             "EndpointDiscovered",
-					Message:            fmt.Sprintf("Endpoint %s:%d discovered from %s/%s", ep.Host, ep.Port, ep.SourceNamespace, ep.SourceName),
+					Message:            fmt.Sprintf("Endpoint %s discovered from %s/%s", hostPort(ep.Host, ep.Port), ep.SourceNamespace, ep.SourceName),
 				},
 			},
 		}
@@ -261,7 +262,7 @@ func (r *EndpointReconciler) processEndpoint(ctx context.Context, ep endpoint.En
 
 		if r.Recorder != nil {
 			r.Recorder.Event(cr, corev1.EventTypeNormal, EventReasonEndpointDiscovered,
-				fmt.Sprintf("Discovered TLS endpoint %s:%d from %s %s/%s", ep.Host, ep.Port, ep.SourceKind, ep.SourceNamespace, ep.SourceName))
+				fmt.Sprintf("Discovered TLS endpoint %s from %s %s/%s", hostPort(ep.Host, ep.Port), ep.SourceKind, ep.SourceNamespace, ep.SourceName))
 		}
 
 		// Launch async TLS check using the caller's context for cancellation
@@ -364,8 +365,8 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 			metrics.RecordRetriesExhausted()
 			if r.Recorder != nil {
 				r.Recorder.Event(&cr, corev1.EventTypeWarning, EventReasonRetryExhausted,
-					fmt.Sprintf("TLS check retries exhausted for %s:%d after %d attempts: %s",
-						host, port, maxAttempts, result.FailureReason))
+					fmt.Sprintf("TLS check retries exhausted for %s after %d attempts: %s",
+						hostPort(host, int32(port)), maxAttempts, result.FailureReason))
 			}
 		}
 		return
@@ -681,24 +682,24 @@ func (r *EndpointReconciler) emitComplianceEvents(cr *securityv1alpha1.TLSCompli
 	// Non-compliance detected — only legacy TLS, no modern TLS support
 	if cr.Status.ComplianceStatus == securityv1alpha1.ComplianceStatusNonCompliant {
 		r.Recorder.Event(cr, corev1.EventTypeWarning, EventReasonTLSNonCompliant,
-			fmt.Sprintf("Endpoint %s:%d only supports legacy TLS versions (no TLS 1.2 or 1.3)", cr.Spec.Host, cr.Spec.Port))
+			fmt.Sprintf("Endpoint %s only supports legacy TLS versions (no TLS 1.2 or 1.3)", hostPort(cr.Spec.Host, cr.Spec.Port)))
 	}
 
 	// Compliance status changed
 	if oldStatus != "" && oldStatus != cr.Status.ComplianceStatus &&
 		oldStatus != securityv1alpha1.ComplianceStatusPending {
 		r.Recorder.Event(cr, corev1.EventTypeWarning, EventReasonComplianceChanged,
-			fmt.Sprintf("Compliance status changed from %s to %s for %s:%d", oldStatus, cr.Status.ComplianceStatus, cr.Spec.Host, cr.Spec.Port))
+			fmt.Sprintf("Compliance status changed from %s to %s for %s", oldStatus, cr.Status.ComplianceStatus, hostPort(cr.Spec.Host, cr.Spec.Port)))
 	}
 
 	// PQC readiness changed
 	if oldPQCReadiness != "" && oldPQCReadiness != cr.Status.PQCReadiness {
 		if cr.Status.PQCReadiness == securityv1alpha1.PQCReadinessPQCReady {
 			r.Recorder.Event(cr, corev1.EventTypeNormal, EventReasonPQCReady,
-				fmt.Sprintf("Endpoint %s:%d is now post-quantum ready (TLS 1.3 + ML-KEM)", cr.Spec.Host, cr.Spec.Port))
+				fmt.Sprintf("Endpoint %s is now post-quantum ready (TLS 1.3 + ML-KEM)", hostPort(cr.Spec.Host, cr.Spec.Port)))
 		} else {
 			r.Recorder.Event(cr, corev1.EventTypeWarning, EventReasonPQCNotReady,
-				fmt.Sprintf("PQC readiness changed from %s to %s for %s:%d", oldPQCReadiness, cr.Status.PQCReadiness, cr.Spec.Host, cr.Spec.Port))
+				fmt.Sprintf("PQC readiness changed from %s to %s for %s", oldPQCReadiness, cr.Status.PQCReadiness, hostPort(cr.Spec.Host, cr.Spec.Port)))
 		}
 	}
 
@@ -706,10 +707,10 @@ func (r *EndpointReconciler) emitComplianceEvents(cr *securityv1alpha1.TLSCompli
 	if result.Certificate != nil {
 		if result.Certificate.IsExpired {
 			r.Recorder.Event(cr, corev1.EventTypeWarning, EventReasonCertificateExpired,
-				fmt.Sprintf("TLS certificate has expired for %s:%d", cr.Spec.Host, cr.Spec.Port))
+				fmt.Sprintf("TLS certificate has expired for %s", hostPort(cr.Spec.Host, cr.Spec.Port)))
 		} else if result.Certificate.DaysUntilExpiry <= r.CertExpiryDays {
 			r.Recorder.Event(cr, corev1.EventTypeWarning, EventReasonCertificateExpiring,
-				fmt.Sprintf("TLS certificate for %s:%d expires in %d days", cr.Spec.Host, cr.Spec.Port, result.Certificate.DaysUntilExpiry))
+				fmt.Sprintf("TLS certificate for %s expires in %d days", hostPort(cr.Spec.Host, cr.Spec.Port), result.Certificate.DaysUntilExpiry))
 		}
 	}
 }
@@ -1097,6 +1098,12 @@ func failureReasonToComplianceStatus(reason tlscheck.FailureReason) securityv1al
 	default:
 		return securityv1alpha1.ComplianceStatusUnreachable
 	}
+}
+
+// hostPort formats a host and port for display, using net.JoinHostPort to
+// correctly bracket IPv6 addresses (e.g. "[::1]:443").
+func hostPort(host string, port int32) string {
+	return net.JoinHostPort(host, fmt.Sprintf("%d", port))
 }
 
 // ParseNamespaceList parses a comma-separated namespace string into a map for O(1) lookups.

--- a/pkg/endpoint/resolver.go
+++ b/pkg/endpoint/resolver.go
@@ -127,9 +127,10 @@ func GenerateCRName(ep Endpoint) string {
 	identity := fmt.Sprintf("%s/%s/%s/%s/%d", ep.SourceKind, ep.SourceNamespace, ep.SourceName, ep.Host, ep.Port)
 	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(identity)))[:8]
 
-	// Sanitize host for use in K8s name
+	// Sanitize host for use in K8s name (dots and colons become hyphens)
 	sanitized := strings.ToLower(ep.Host)
 	sanitized = strings.ReplaceAll(sanitized, ".", "-")
+	sanitized = strings.ReplaceAll(sanitized, ":", "-")
 	sanitized = sanitizeRegex.ReplaceAllString(sanitized, "")
 
 	// Trim trailing hyphens
@@ -232,13 +233,39 @@ func resolveProbePort(port intstr.IntOrString, portNames map[string]int32) int32
 	return 0
 }
 
+// podIPs returns all IP addresses for a pod, supporting dual-stack clusters.
+// Falls back to the singular PodIP field for older clusters.
+func podIPs(pod *corev1.Pod) []string {
+	if len(pod.Status.PodIPs) > 0 {
+		ips := make([]string, 0, len(pod.Status.PodIPs))
+		for _, pip := range pod.Status.PodIPs {
+			if pip.IP != "" {
+				ips = append(ips, pip.IP)
+			}
+		}
+		if len(ips) > 0 {
+			return ips
+		}
+	}
+	if pod.Status.PodIP != "" {
+		return []string{pod.Status.PodIP}
+	}
+	return nil
+}
+
 // ExtractFromPod returns TLS endpoints from a Pod.
 // It inspects container ports for TLS-likely ports (443, 8443, or named https/https-*).
+// On dual-stack clusters, endpoints are created for each pod IP (IPv4 and IPv6).
 // Ports used only by HTTP/TCP health probes are skipped (plaintext expected).
 // HTTPS health probe ports are still included but marked as probe ports.
 // Only Running pods with a PodIP are considered. Init containers are skipped.
 func ExtractFromPod(pod *corev1.Pod) []Endpoint {
-	if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+	if pod.Status.Phase != corev1.PodRunning {
+		return nil
+	}
+
+	ips := podIPs(pod)
+	if len(ips) == 0 {
 		return nil
 	}
 
@@ -263,14 +290,16 @@ func ExtractFromPod(pod *corev1.Pod) []Endpoint {
 					continue
 				}
 
-				endpoints = append(endpoints, Endpoint{
-					Host:            pod.Status.PodIP,
-					Port:            port.ContainerPort,
-					SourceKind:      "Pod",
-					SourceNamespace: pod.Namespace,
-					SourceName:      pod.Name,
-					IsProbePort:     isProbe,
-				})
+				for _, ip := range ips {
+					endpoints = append(endpoints, Endpoint{
+						Host:            ip,
+						Port:            port.ContainerPort,
+						SourceKind:      "Pod",
+						SourceNamespace: pod.Namespace,
+						SourceName:      pod.Name,
+						IsProbePort:     isProbe,
+					})
+				}
 			}
 		}
 	}

--- a/pkg/endpoint/resolver_test.go
+++ b/pkg/endpoint/resolver_test.go
@@ -862,6 +862,87 @@ func TestExtractFromPod_GRPCProbePortSkipped(t *testing.T) {
 	}
 }
 
+func TestExtractFromPod_IPv6PodIP(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Ports: []corev1.ContainerPort{{ContainerPort: 443}}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
+			PodIP:  "fd00::1",
+			PodIPs: []corev1.PodIP{{IP: "fd00::1"}},
+		},
+	}
+
+	endpoints := ExtractFromPod(pod)
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint for IPv6 pod, got %d", len(endpoints))
+	}
+	if endpoints[0].Host != "fd00::1" {
+		t.Errorf("host = %q, want fd00::1", endpoints[0].Host)
+	}
+}
+
+func TestExtractFromPod_DualStack(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Ports: []corev1.ContainerPort{{ContainerPort: 443}}},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.244.1.5",
+			PodIPs: []corev1.PodIP{
+				{IP: "10.244.1.5"},
+				{IP: "fd00::5"},
+			},
+		},
+	}
+
+	endpoints := ExtractFromPod(pod)
+	if len(endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints for dual-stack pod, got %d", len(endpoints))
+	}
+
+	hosts := map[string]bool{}
+	for _, ep := range endpoints {
+		hosts[ep.Host] = true
+	}
+	if !hosts["10.244.1.5"] {
+		t.Error("missing IPv4 endpoint")
+	}
+	if !hosts["fd00::5"] {
+		t.Error("missing IPv6 endpoint")
+	}
+}
+
+func TestGenerateCRName_IPv6(t *testing.T) {
+	ep := Endpoint{
+		Host:            "2001:db8::1",
+		Port:            443,
+		SourceKind:      "Pod",
+		SourceNamespace: "default",
+		SourceName:      "my-pod",
+	}
+
+	name := GenerateCRName(ep)
+
+	if len(name) > MaxCRNameLength {
+		t.Errorf("name too long: %d > %d", len(name), MaxCRNameLength)
+	}
+	if strings.Contains(name, ":") {
+		t.Errorf("name contains colon: %q", name)
+	}
+	if !strings.Contains(name, "2001-db8--1") {
+		t.Errorf("expected readable IPv6 in name, got: %q", name)
+	}
+}
+
 func TestExtractFromPod_DefaultProtocol(t *testing.T) {
 	// When protocol is not specified, it defaults to TCP
 	pod := &corev1.Pod{

--- a/pkg/tlscheck/sslprobe.go
+++ b/pkg/tlscheck/sslprobe.go
@@ -149,4 +149,3 @@ func isSSL30ServerHello(conn net.Conn) bool {
 	// Server version in the ServerHello body must be SSL 3.0
 	return handshakeHeader[4] == sslVersionSSL30Major && handshakeHeader[5] == sslVersionSSL30Minor
 }
-


### PR DESCRIPTION
## Summary

- ExtractFromPod reads pod.Status.PodIPs for dual-stack clusters, creating endpoints for both IPv4 and IPv6 addresses (falls back to PodIP for single-stack)
- CR name generation converts IPv6 colons to hyphens for readability
- All event messages use net.JoinHostPort for correct IPv6 bracket formatting
- Tests for IPv6 pod IPs, dual-stack pods, and IPv6 CR name generation

## Test plan

- [x] make build succeeds
- [x] make lint -- zero issues
- [x] All unit tests pass (3 new IPv6 tests + all existing pass)
- [ ] CI checks pass