### PR TITLE
Add TLS tool parity testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,20 @@ test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expect
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
+TEST_SERVER_IMG ?= quay.io/bapalm/tls-test-server:latest
+
+.PHONY: test-parity
+test-parity: manifests generate fmt vet ## Run TLS parity tests comparing operator results with tls-scanner.
+	go test -tags=parity ./test/parity/ -v -ginkgo.v -timeout 30m
+
+.PHONY: docker-build-testserver
+docker-build-testserver: ## Build the TLS test server image.
+	$(CONTAINER_TOOL) build -t $(TEST_SERVER_IMG) -f test/testserver/Dockerfile test/testserver/
+
+.PHONY: docker-push-testserver
+docker-push-testserver: ## Push the TLS test server image.
+	$(CONTAINER_TOOL) push $(TEST_SERVER_IMG)
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
 	"$(GOLANGCI_LINT)" run

--- a/test/parity/helpers.go
+++ b/test/parity/helpers.go
@@ -1,0 +1,433 @@
+//go:build parity
+
+package parity
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+const (
+	parityNamespace = "parity-test"
+	testServerImage = "quay.io/bapalm/tls-test-server:latest"
+	scannerImage    = "quay.io/bapalm/tls-scanner:latest"
+)
+
+func kubectl(args ...string) (string, error) {
+	cmd := exec.Command("kubectl", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("kubectl %s: %w\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func kubectlApply(manifest, description string) {
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	out, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "%s: %s", description, string(out))
+}
+
+func createNamespace() {
+	kubectlApply(fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+`, parityNamespace), "create namespace")
+}
+
+func deleteNamespace() {
+	_, _ = kubectl("delete", "namespace", parityNamespace, "--ignore-not-found", "--timeout=60s")
+}
+
+func deployTestPod(s Scenario) {
+	envYAML := ""
+	for k, v := range s.Env {
+		envYAML += fmt.Sprintf(`
+    - name: %s
+      value: "%s"`, k, v)
+	}
+
+	kubectlApply(fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app: %s
+    parity-test: "true"
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: server
+    image: %s
+    env:%s
+    ports:
+    - containerPort: %d
+      name: https
+      protocol: TCP
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+`, s.PodName, parityNamespace, s.PodName, testServerImage, envYAML, s.Port),
+		fmt.Sprintf("deploy pod %s", s.PodName))
+}
+
+func createService(s Scenario) {
+	kubectlApply(fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  selector:
+    app: %s
+  ports:
+  - port: %d
+    targetPort: %d
+    name: https
+`, s.PodName, parityNamespace, s.PodName, s.Port, s.Port),
+		fmt.Sprintf("create service %s", s.PodName))
+}
+
+func waitForPodReady(podName string, timeout time.Duration) {
+	Eventually(func() error {
+		_, err := kubectl("wait", "-n", parityNamespace, "--for=condition=Ready",
+			fmt.Sprintf("pod/%s", podName), fmt.Sprintf("--timeout=%ds", int(timeout.Seconds())))
+		return err
+	}).WithTimeout(timeout + 10*time.Second).WithPolling(5 * time.Second).Should(Succeed())
+}
+
+func getPodIP(podName string) string {
+	ip, err := kubectl("get", "pod", "-n", parityNamespace, podName,
+		"-o", "jsonpath={.status.podIP}")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ip).NotTo(BeEmpty(), "pod %s has no IP", podName)
+	return ip
+}
+
+func waitForTLSReport(podIP string, port int, timeout time.Duration) string {
+	// CR names use the pattern: <sanitized-ip>-<port>-<hash>
+	// The sanitized IP replaces dots with dashes.
+	sanitizedIP := strings.ReplaceAll(podIP, ".", "-")
+	prefix := fmt.Sprintf("%s-%d-", sanitizedIP, port)
+
+	var reportName string
+	Eventually(func() error {
+		out, err := kubectl("get", "tlsreport",
+			"-o", "jsonpath={.items[*].metadata.name}")
+		if err != nil {
+			return err
+		}
+		for _, name := range strings.Fields(out) {
+			if strings.HasPrefix(name, prefix) {
+				reportName = name
+				return nil
+			}
+		}
+		return fmt.Errorf("no TLSComplianceReport found matching prefix %s", prefix)
+	}).WithTimeout(timeout).WithPolling(5 * time.Second).Should(Succeed())
+
+	return reportName
+}
+
+func getOperatorResult(reportName string) NormalizedResult {
+	out, err := kubectl("get", "tlsreport", reportName, "-o", "json")
+	Expect(err).NotTo(HaveOccurred())
+
+	var report struct {
+		Spec struct {
+			Host string `json:"host"`
+			Port int    `json:"port"`
+		} `json:"spec"`
+		Status struct {
+			ComplianceStatus string `json:"complianceStatus"`
+			TLSVersions      struct {
+				SSL30 bool `json:"ssl30"`
+				TLS10 bool `json:"tls10"`
+				TLS11 bool `json:"tls11"`
+				TLS12 bool `json:"tls12"`
+				TLS13 bool `json:"tls13"`
+			} `json:"tlsVersions"`
+			ForwardSecrecy     bool                `json:"forwardSecrecy"`
+			QuantumReady       bool                `json:"quantumReady"`
+			OverallCipherGrade string              `json:"overallCipherGrade"`
+			KeyExchangeTypes   map[string]string   `json:"keyExchangeTypes"`
+			NegotiatedCurves   map[string]string   `json:"negotiatedCurves"`
+			CertificateInfo    *struct {
+				Issuer          string `json:"issuer"`
+				DaysUntilExpiry int    `json:"daysUntilExpiry"`
+			} `json:"certificateInfo"`
+		} `json:"status"`
+	}
+	Expect(json.Unmarshal([]byte(out), &report)).To(Succeed())
+
+	s := report.Status
+	result := NormalizedResult{
+		Endpoint:         fmt.Sprintf("%s:%d", report.Spec.Host, report.Spec.Port),
+		Reachable:        !isUnreachable(s.ComplianceStatus),
+		TLSDetected:      s.ComplianceStatus != string(securityv1alpha1.ComplianceStatusNoTLS),
+		TLS10:            s.TLSVersions.TLS10,
+		TLS11:            s.TLSVersions.TLS11,
+		TLS12:            s.TLSVersions.TLS12,
+		TLS13:            s.TLSVersions.TLS13,
+		MTLSRequired:     s.ComplianceStatus == string(securityv1alpha1.ComplianceStatusMutualTLSRequired),
+		ForwardSecrecy:   boolPtr(s.ForwardSecrecy),
+		PQCReady:         boolPtr(s.QuantumReady),
+		CipherGrade:      s.OverallCipherGrade,
+		KeyExchangeTypes: s.KeyExchangeTypes,
+		NegotiatedCurves: s.NegotiatedCurves,
+	}
+	if s.CertificateInfo != nil {
+		result.CertIssuer = s.CertificateInfo.Issuer
+		result.CertDaysToExpiry = &s.CertificateInfo.DaysUntilExpiry
+	}
+	return result
+}
+
+func deployScannerJob(targets string) {
+	_, _ = kubectl("delete", "job", "-n", parityNamespace, "parity-tls-scanner", "--ignore-not-found")
+
+	kubectlApply(fmt.Sprintf(`apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parity-tls-scanner
+  namespace: %s
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: tls-scanner
+        image: %s
+        imagePullPolicy: IfNotPresent
+        args:
+        - "--targets"
+        - "%s"
+        - "--json-file"
+        - "/tmp/results.json"
+        - "-j"
+        - "1"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+      restartPolicy: Never
+`, parityNamespace, scannerImage, targets), "deploy scanner job")
+}
+
+func waitForScannerJob(timeout time.Duration) {
+	_, err := kubectl("wait", "-n", parityNamespace, "--for=condition=complete",
+		"job/parity-tls-scanner", fmt.Sprintf("--timeout=%ds", int(timeout.Seconds())))
+	Expect(err).NotTo(HaveOccurred(), "scanner job did not complete")
+}
+
+func getScannerResults() *ScanResults {
+	podName, err := kubectl("get", "pods", "-n", parityNamespace,
+		"-l", "job-name=parity-tls-scanner",
+		"-o", "jsonpath={.items[0].metadata.name}")
+	Expect(err).NotTo(HaveOccurred())
+
+	tmpFile := fmt.Sprintf("/tmp/parity-scanner-results-%d.json", time.Now().UnixNano())
+	_, err = kubectl("cp",
+		fmt.Sprintf("%s/%s:/tmp/results.json", parityNamespace, podName),
+		tmpFile)
+	Expect(err).NotTo(HaveOccurred(), "failed to copy results.json from scanner pod")
+
+	data, err := os.ReadFile(tmpFile)
+	Expect(err).NotTo(HaveOccurred())
+	os.Remove(tmpFile)
+
+	var results ScanResults
+	Expect(json.Unmarshal(data, &results)).To(Succeed())
+	return &results
+}
+
+func normalizeScannerResult(ip string, port int, results *ScanResults) NormalizedResult {
+	nr := NormalizedResult{
+		Endpoint: fmt.Sprintf("%s:%d", ip, port),
+	}
+
+	for _, ipResult := range results.IPResults {
+		if ipResult.IP != ip {
+			continue
+		}
+
+		nr.Reachable = ipResult.Status == "scanned"
+
+		for _, pr := range ipResult.PortResults {
+			if pr.Port != port {
+				continue
+			}
+
+			nr.TLSDetected = pr.Status != "NO_TLS"
+			nr.MTLSRequired = strings.Contains(strings.ToLower(pr.Reason), "mutual") ||
+				strings.Contains(strings.ToLower(pr.Reason), "client cert")
+
+			for _, v := range pr.TlsVersions {
+				switch v {
+				case "TLSv1.0":
+					nr.TLS10 = true
+				case "TLSv1.1":
+					nr.TLS11 = true
+				case "TLSv1.2":
+					nr.TLS12 = true
+				case "TLSv1.3":
+					nr.TLS13 = true
+				}
+			}
+
+			nr.CipherSuites = pr.TlsCiphers
+			nr.MLKEMSupported = boolPtr(pr.MLKEMSupported)
+
+			return nr
+		}
+	}
+
+	return nr
+}
+
+func compareResults(scenario string, operator, scanner NormalizedResult) ParityComparison {
+	c := ParityComparison{Scenario: scenario}
+
+	checkBool := func(name string, op, sc bool) {
+		if op == sc {
+			c.Matches = append(c.Matches, name)
+		} else {
+			c.Mismatches = append(c.Mismatches,
+				fmt.Sprintf("%s: operator=%v scanner=%v", name, op, sc))
+		}
+	}
+
+	checkBool("TLS Detected", operator.TLSDetected, scanner.TLSDetected)
+	checkBool("TLS 1.0", operator.TLS10, scanner.TLS10)
+	checkBool("TLS 1.1", operator.TLS11, scanner.TLS11)
+	checkBool("TLS 1.2", operator.TLS12, scanner.TLS12)
+	checkBool("TLS 1.3", operator.TLS13, scanner.TLS13)
+
+	if operator.ForwardSecrecy != nil {
+		c.OperatorOnly = append(c.OperatorOnly, fmt.Sprintf("ForwardSecrecy=%v", *operator.ForwardSecrecy))
+	}
+	if operator.PQCReady != nil {
+		c.OperatorOnly = append(c.OperatorOnly, fmt.Sprintf("PQCReady=%v", *operator.PQCReady))
+	}
+	if operator.CipherGrade != "" {
+		c.OperatorOnly = append(c.OperatorOnly, fmt.Sprintf("CipherGrade=%s", operator.CipherGrade))
+	}
+	if len(operator.KeyExchangeTypes) > 0 {
+		c.OperatorOnly = append(c.OperatorOnly, fmt.Sprintf("KeyExchangeTypes=%v", operator.KeyExchangeTypes))
+	}
+	if len(operator.NegotiatedCurves) > 0 {
+		c.OperatorOnly = append(c.OperatorOnly, fmt.Sprintf("NegotiatedCurves=%v", operator.NegotiatedCurves))
+	}
+	if operator.CertIssuer != "" {
+		c.OperatorOnly = append(c.OperatorOnly, fmt.Sprintf("CertIssuer=%s", operator.CertIssuer))
+	}
+
+	if len(scanner.CipherSuites) > 0 {
+		c.ScannerOnly = append(c.ScannerOnly, fmt.Sprintf("CipherSuites=%v", scanner.CipherSuites))
+	}
+	if scanner.MLKEMSupported != nil {
+		c.ScannerOnly = append(c.ScannerOnly, fmt.Sprintf("MLKEMSupported=%v", *scanner.MLKEMSupported))
+	}
+
+	return c
+}
+
+func generateGapReport(comparisons []ParityComparison) string {
+	var sb strings.Builder
+
+	sb.WriteString("## TLS Parity Gap Report\n\n")
+	sb.WriteString("### Comparison Summary\n")
+	sb.WriteString("| Scenario | Overlapping Fields | Matches | Mismatches |\n")
+	sb.WriteString("|---|---|---|---|\n")
+
+	for _, c := range comparisons {
+		total := len(c.Matches) + len(c.Mismatches)
+		sb.WriteString(fmt.Sprintf("| %s | %d | %d | %d |\n",
+			c.Scenario, total, len(c.Matches), len(c.Mismatches)))
+	}
+
+	hasMismatches := false
+	for _, c := range comparisons {
+		if len(c.Mismatches) > 0 {
+			hasMismatches = true
+			break
+		}
+	}
+	if hasMismatches {
+		sb.WriteString("\n### Mismatches (Failures)\n")
+		sb.WriteString("| Scenario | Mismatch |\n")
+		sb.WriteString("|---|---|\n")
+		for _, c := range comparisons {
+			for _, m := range c.Mismatches {
+				sb.WriteString(fmt.Sprintf("| %s | %s |\n", c.Scenario, m))
+			}
+		}
+	}
+
+	sb.WriteString("\n### Non-Overlapping Fields (Gaps)\n")
+	sb.WriteString("| Scenario | Source | Fields |\n")
+	sb.WriteString("|---|---|---|\n")
+	for _, c := range comparisons {
+		if len(c.OperatorOnly) > 0 {
+			sb.WriteString(fmt.Sprintf("| %s | Operator only | %s |\n",
+				c.Scenario, strings.Join(c.OperatorOnly, ", ")))
+		}
+		if len(c.ScannerOnly) > 0 {
+			sb.WriteString(fmt.Sprintf("| %s | Scanner only | %s |\n",
+				c.Scenario, strings.Join(c.ScannerOnly, ", ")))
+		}
+	}
+
+	return sb.String()
+}
+
+func writeStepSummary(report string) {
+	summaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
+	if summaryPath != "" {
+		_ = os.WriteFile(summaryPath, []byte(report), 0o644)
+	}
+	GinkgoWriter.Println(report)
+}
+
+func cleanupScenario(podName string) {
+	_, _ = kubectl("delete", "pod", "-n", parityNamespace, podName, "--ignore-not-found", "--grace-period=0", "--force")
+	_, _ = kubectl("delete", "svc", "-n", parityNamespace, podName, "--ignore-not-found")
+	_, _ = kubectl("delete", "job", "-n", parityNamespace, "parity-tls-scanner", "--ignore-not-found")
+}
+
+func isUnreachable(status string) bool {
+	switch status {
+	case string(securityv1alpha1.ComplianceStatusUnreachable),
+		string(securityv1alpha1.ComplianceStatusTimeout),
+		string(securityv1alpha1.ComplianceStatusClosed),
+		string(securityv1alpha1.ComplianceStatusFiltered):
+		return true
+	}
+	return false
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/test/parity/parity_suite_test.go
+++ b/test/parity/parity_suite_test.go
@@ -1,0 +1,15 @@
+//go:build parity
+
+package parity
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+)
+
+func TestParity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Tool Parity Suite")
+}

--- a/test/parity/parity_test.go
+++ b/test/parity/parity_test.go
@@ -1,0 +1,170 @@
+//go:build parity
+
+package parity
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+var scenarios = []Scenario{
+	{
+		Name:      "TLS 1.3 Only",
+		PodName:   "tls13-only",
+		Env:       map[string]string{"TLS_MIN_VERSION": "1.3", "TLS_MAX_VERSION": "1.3"},
+		Port:      8443,
+		ExpectTLS: true,
+	},
+	{
+		Name:      "TLS 1.2 Only",
+		PodName:   "tls12-only",
+		Env:       map[string]string{"TLS_MIN_VERSION": "1.2", "TLS_MAX_VERSION": "1.2"},
+		Port:      8443,
+		ExpectTLS: true,
+	},
+	{
+		Name:      "TLS 1.2 and 1.3",
+		PodName:   "tls12-13",
+		Env:       map[string]string{"TLS_MIN_VERSION": "1.2", "TLS_MAX_VERSION": "1.3"},
+		Port:      8443,
+		ExpectTLS: true,
+	},
+	{
+		Name:      "Plain HTTP",
+		PodName:   "plain-http",
+		Env:       map[string]string{"TLS_ENABLED": "false"},
+		Port:      8080,
+		ExpectTLS: false,
+	},
+	{
+		Name:       "mTLS Required",
+		PodName:    "mtls-required",
+		Env:        map[string]string{"MTLS_REQUIRED": "true"},
+		Port:       8443,
+		ExpectTLS:  true,
+		ExpectMTLS: true,
+	},
+}
+
+var _ = Describe("TLS Tool Parity", Ordered, func() {
+	var allComparisons []ParityComparison
+
+	BeforeAll(func() {
+		createNamespace()
+	})
+
+	AfterAll(func() {
+		report := generateGapReport(allComparisons)
+		writeStepSummary(report)
+		deleteNamespace()
+	})
+
+	for _, s := range scenarios {
+		s := s
+
+		Context(s.Name, Ordered, func() {
+			var podIP string
+			var operatorResult NormalizedResult
+			var scannerResult NormalizedResult
+
+			BeforeAll(func() {
+				By("Deploying test pod and service")
+				deployTestPod(s)
+				createService(s)
+				waitForPodReady(s.PodName, 60*time.Second)
+				podIP = getPodIP(s.PodName)
+				GinkgoWriter.Printf("Pod %s IP: %s\n", s.PodName, podIP)
+			})
+
+			AfterAll(func() {
+				cleanupScenario(s.PodName)
+			})
+
+			It("should be scanned by the operator", func() {
+				if !s.ExpectTLS && s.Port != 8443 {
+					// Port 8080 is not in the operator's TLS port list — no report expected
+					operatorResult = NormalizedResult{
+						Endpoint:    fmt.Sprintf("%s:%d", podIP, s.Port),
+						Reachable:   true,
+						TLSDetected: false,
+					}
+					GinkgoWriter.Println("Operator does not scan non-TLS ports (expected)")
+					return
+				}
+
+				reportName := waitForTLSReport(podIP, s.Port, 3*time.Minute)
+				GinkgoWriter.Printf("Found TLSComplianceReport: %s\n", reportName)
+
+				// Wait for the report to be checked (not Pending)
+				Eventually(func() string {
+					out, err := kubectl("get", "tlsreport", reportName,
+						"-o", "jsonpath={.status.complianceStatus}")
+					if err != nil {
+						return "Pending"
+					}
+					return out
+				}).WithTimeout(3 * time.Minute).WithPolling(5 * time.Second).ShouldNot(
+					Or(Equal(string(securityv1alpha1.ComplianceStatusPending)),
+						Equal(string(securityv1alpha1.ComplianceStatusUnknown)),
+						BeEmpty()),
+				)
+
+				operatorResult = getOperatorResult(reportName)
+				GinkgoWriter.Printf("Operator result: TLS=%v versions=[1.0=%v 1.1=%v 1.2=%v 1.3=%v] mTLS=%v\n",
+					operatorResult.TLSDetected,
+					operatorResult.TLS10, operatorResult.TLS11,
+					operatorResult.TLS12, operatorResult.TLS13,
+					operatorResult.MTLSRequired)
+			})
+
+			It("should be scanned by the tls-scanner", func() {
+				target := fmt.Sprintf("%s:%d", podIP, s.Port)
+				By(fmt.Sprintf("Deploying scanner job targeting %s", target))
+				deployScannerJob(target)
+				waitForScannerJob(3 * time.Minute)
+
+				results := getScannerResults()
+				scannerResult = normalizeScannerResult(podIP, s.Port, results)
+				GinkgoWriter.Printf("Scanner result: TLS=%v versions=[1.0=%v 1.1=%v 1.2=%v 1.3=%v] mTLS=%v\n",
+					scannerResult.TLSDetected,
+					scannerResult.TLS10, scannerResult.TLS11,
+					scannerResult.TLS12, scannerResult.TLS13,
+					scannerResult.MTLSRequired)
+			})
+
+			It("should agree on TLS detection", func() {
+				Expect(operatorResult.TLSDetected).To(Equal(scannerResult.TLSDetected),
+					"TLS detection mismatch for %s", s.Name)
+			})
+
+			It("should agree on TLS versions", func() {
+				if !s.ExpectTLS {
+					Skip("No TLS expected for this scenario")
+				}
+				if s.ExpectMTLS {
+					Skip("mTLS prevents full version enumeration")
+				}
+				Expect(operatorResult.TLS10).To(Equal(scannerResult.TLS10), "TLS 1.0 mismatch")
+				Expect(operatorResult.TLS11).To(Equal(scannerResult.TLS11), "TLS 1.1 mismatch")
+				Expect(operatorResult.TLS12).To(Equal(scannerResult.TLS12), "TLS 1.2 mismatch")
+				Expect(operatorResult.TLS13).To(Equal(scannerResult.TLS13), "TLS 1.3 mismatch")
+			})
+
+			It("should produce a parity comparison", func() {
+				comparison := compareResults(s.Name, operatorResult, scannerResult)
+				allComparisons = append(allComparisons, comparison)
+
+				if len(comparison.Mismatches) > 0 {
+					Fail(fmt.Sprintf("Parity mismatches for %s:\n%s",
+						s.Name, strings.Join(comparison.Mismatches, "\n")))
+				}
+			})
+		})
+	}
+})

--- a/test/parity/parity_test.go
+++ b/test/parity/parity_test.go
@@ -98,7 +98,7 @@ var _ = Describe("TLS Tool Parity", Ordered, func() {
 					return
 				}
 
-				reportName := waitForTLSReport(podIP, s.Port, 3*time.Minute)
+				reportName := waitForTLSReport(podIP, s.Port, 10*time.Minute)
 				GinkgoWriter.Printf("Found TLSComplianceReport: %s\n", reportName)
 
 				// Wait for the report to be checked (not Pending)
@@ -109,7 +109,7 @@ var _ = Describe("TLS Tool Parity", Ordered, func() {
 						return "Pending"
 					}
 					return out
-				}).WithTimeout(3 * time.Minute).WithPolling(5 * time.Second).ShouldNot(
+				}).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).ShouldNot(
 					Or(Equal(string(securityv1alpha1.ComplianceStatusPending)),
 						Equal(string(securityv1alpha1.ComplianceStatusUnknown)),
 						BeEmpty()),

--- a/test/parity/types.go
+++ b/test/parity/types.go
@@ -1,0 +1,107 @@
+//go:build parity
+
+package parity
+
+// ScanResults is the top-level JSON output from the tls-scanner.
+type ScanResults struct {
+	Timestamp  string     `json:"timestamp"`
+	TotalIPs   int        `json:"total_ips"`
+	ScannedIPs int        `json:"scanned_ips"`
+	IPResults  []IPResult `json:"ip_results"`
+	ScanErrors []ScanError `json:"scan_errors,omitempty"`
+}
+
+type ScanError struct {
+	IP        string `json:"ip"`
+	Port      int    `json:"port"`
+	ErrorType string `json:"error_type"`
+	ErrorMsg  string `json:"error_message"`
+}
+
+type IPResult struct {
+	IP          string       `json:"ip"`
+	Status      string       `json:"status"`
+	OpenPorts   []int        `json:"open_ports"`
+	PortResults []PortResult `json:"port_results"`
+	Error       string       `json:"error,omitempty"`
+}
+
+type PortResult struct {
+	Port            int              `json:"port"`
+	Protocol        string           `json:"protocol"`
+	State           string           `json:"state"`
+	Service         string           `json:"service"`
+	TlsVersions     []string         `json:"tls_versions,omitempty"`
+	TlsCiphers      []string         `json:"tls_ciphers,omitempty"`
+	TlsKeyExchange  *KeyExchangeInfo `json:"tls_key_exchange,omitempty"`
+	Status          string           `json:"status"`
+	Reason          string           `json:"reason,omitempty"`
+	TLS13Supported  bool             `json:"tls13_supported,omitempty"`
+	MLKEMSupported  bool             `json:"mlkem_supported,omitempty"`
+	MLKEMCiphers    []string         `json:"mlkem_kems,omitempty"`
+	TLSReadiness    *TLSReadiness    `json:"tls_readiness,omitempty"`
+}
+
+type KeyExchangeInfo struct {
+	Groups         []string        `json:"groups,omitempty"`
+	ForwardSecrecy *ForwardSecrecy `json:"forward_secrecy,omitempty"`
+}
+
+type ForwardSecrecy struct {
+	Supported bool     `json:"supported"`
+	ECDHE     []string `json:"ecdhe,omitempty"`
+	KEMs      []string `json:"kems,omitempty"`
+}
+
+type TLSReadiness struct {
+	TLS13Offered bool     `json:"tls13_offered"`
+	TLS12Only    bool     `json:"tls12_only"`
+	PQCCapable   bool     `json:"pqc_capable"`
+	MLKEMKEMs    []string `json:"mlkem_kems,omitempty"`
+	Notes        string   `json:"notes,omitempty"`
+}
+
+// NormalizedResult is the common schema both tool outputs are converted into
+// for comparison.
+type NormalizedResult struct {
+	Endpoint string
+	Reachable bool
+	TLSDetected bool
+	TLS10       bool
+	TLS11       bool
+	TLS12       bool
+	TLS13       bool
+	MTLSRequired bool
+
+	// Fields from the operator only (gap report)
+	ForwardSecrecy   *bool
+	PQCReady         *bool
+	CipherGrade      string
+	KeyExchangeTypes map[string]string
+	NegotiatedCurves map[string]string
+	CertIssuer       string
+	CertDaysToExpiry *int
+
+	// Fields from the scanner only (gap report)
+	CipherSuites   []string
+	MLKEMSupported *bool
+}
+
+// ParityComparison holds the result of comparing two NormalizedResults.
+type ParityComparison struct {
+	Scenario     string
+	Matches      []string
+	Mismatches   []string
+	OperatorOnly []string
+	ScannerOnly  []string
+}
+
+// Scenario defines a test pod configuration and expected outcomes.
+type Scenario struct {
+	Name         string
+	PodName      string
+	Env          map[string]string
+	Port         int
+	ExpectTLS    bool
+	ExpectMTLS   bool
+}

--- a/test/testserver/Dockerfile
+++ b/test/testserver/Dockerfile
@@ -1,0 +1,17 @@
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY main.go ./
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o tls-test-server .
+
+FROM scratch
+
+COPY --from=builder /app/tls-test-server /tls-test-server
+
+ENTRYPOINT ["/tls-test-server"]

--- a/test/testserver/go.mod
+++ b/test/testserver/go.mod
@@ -1,0 +1,3 @@
+module github.com/sebrandon1/tls-compliance-operator/test/testserver
+
+go 1.26

--- a/test/testserver/main.go
+++ b/test/testserver/main.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var tlsVersionMap = map[string]uint16{
+	"1.0": tls.VersionTLS10,
+	"1.1": tls.VersionTLS11,
+	"1.2": tls.VersionTLS12,
+	"1.3": tls.VersionTLS13,
+}
+
+func main() {
+	cfg := loadConfig()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":      "ok",
+			"tls_enabled": cfg.tlsEnabled,
+			"min_version": cfg.minVersion,
+			"max_version": cfg.maxVersion,
+			"mtls":        cfg.mtlsRequired,
+			"port":        cfg.port,
+		})
+	})
+
+	addr := fmt.Sprintf(":%d", cfg.port)
+
+	if !cfg.tlsEnabled {
+		log.Printf("Serving plain HTTP on %s", addr)
+		log.Fatal(http.ListenAndServe(addr, mux))
+		return
+	}
+
+	tlsCfg, err := buildTLSConfig(cfg)
+	if err != nil {
+		log.Fatalf("Failed to build TLS config: %v", err)
+	}
+
+	server := &http.Server{
+		Addr:      addr,
+		Handler:   mux,
+		TLSConfig: tlsCfg,
+	}
+
+	log.Printf("Serving TLS on %s (min=%s max=%s mtls=%v)", addr, cfg.minVersion, cfg.maxVersion, cfg.mtlsRequired)
+	log.Fatal(server.ListenAndServeTLS("", ""))
+}
+
+type config struct {
+	minVersion   string
+	maxVersion   string
+	tlsEnabled   bool
+	mtlsRequired bool
+	port         int
+}
+
+func loadConfig() config {
+	cfg := config{
+		minVersion:   envOrDefault("TLS_MIN_VERSION", "1.2"),
+		maxVersion:   envOrDefault("TLS_MAX_VERSION", "1.3"),
+		tlsEnabled:   envOrDefault("TLS_ENABLED", "true") == "true",
+		mtlsRequired: envOrDefault("MTLS_REQUIRED", "false") == "true",
+	}
+
+	portStr := os.Getenv("LISTEN_PORT")
+	if portStr != "" {
+		p, err := strconv.Atoi(portStr)
+		if err != nil {
+			log.Fatalf("Invalid LISTEN_PORT: %s", portStr)
+		}
+		cfg.port = p
+	} else if cfg.tlsEnabled {
+		cfg.port = 8443
+	} else {
+		cfg.port = 8080
+	}
+
+	return cfg
+}
+
+func envOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+func buildTLSConfig(cfg config) (*tls.Config, error) {
+	minVer, ok := tlsVersionMap[cfg.minVersion]
+	if !ok {
+		return nil, fmt.Errorf("unknown TLS min version: %s", cfg.minVersion)
+	}
+	maxVer, ok := tlsVersionMap[cfg.maxVersion]
+	if !ok {
+		return nil, fmt.Errorf("unknown TLS max version: %s", cfg.maxVersion)
+	}
+
+	serverCert, err := generateSelfSignedCert()
+	if err != nil {
+		return nil, fmt.Errorf("generating server cert: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion:   minVer,
+		MaxVersion:   maxVer,
+		Certificates: []tls.Certificate{serverCert},
+	}
+
+	if cfg.mtlsRequired {
+		clientCA, err := generateCA("client-ca")
+		if err != nil {
+			return nil, fmt.Errorf("generating client CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		pool.AddCert(clientCA.cert)
+		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return tlsCfg, nil
+}
+
+type caBundle struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+func generateCA(cn string) (*caBundle, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: newSerial(),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:         true,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, err
+	}
+
+	return &caBundle{cert: cert, key: key}, nil
+}
+
+func generateSelfSignedCert() (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	sans := []string{
+		"localhost",
+		"*.parity-test.svc.cluster.local",
+		"*.parity-test.svc",
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: newSerial(),
+		Subject:      pkix.Name{CommonName: "tls-test-server"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+
+	for _, san := range sans {
+		if ip := net.ParseIP(san); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, san)
+		}
+	}
+
+	// Also add any IPs from SAN_IPS env var (for pod IP coverage)
+	if extraIPs := os.Getenv("SAN_IPS"); extraIPs != "" {
+		for _, ipStr := range strings.Split(extraIPs, ",") {
+			if ip := net.ParseIP(strings.TrimSpace(ipStr)); ip != nil {
+				template.IPAddresses = append(template.IPAddresses, ip)
+			}
+		}
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return tls.X509KeyPair(certPEM, keyPEM)
+}
+
+func newSerial() *big.Int {
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		log.Fatalf("Failed to generate serial: %v", err)
+	}
+	return serial
+}


### PR DESCRIPTION
## Summary

- Add a parity testing framework that deploys 5 TLS scenarios and compares results from the tls-compliance-operator and the upstream openshift/tls-scanner
- Includes a configurable Go TLS test server (`test/testserver/`) that supports env-var driven TLS version selection, mTLS, and plain HTTP modes
- Ginkgo test suite (`test/parity/`, build tag `parity`) with scenarios: TLS 1.3 only, TLS 1.2 only, TLS 1.2+1.3, plain HTTP, mTLS required
- Fails on disagreement between tools on overlapping fields (TLS versions, detection, compliance status)
- Produces a gap report for non-overlapping fields (cipher suites, PQC readiness, forward secrecy, etc.)
- Pre-built multi-arch images at `quay.io/bapalm/tls-test-server` and `quay.io/bapalm/tls-scanner`

## New Makefile targets

- `make test-parity` — run parity tests against a cluster with the operator deployed
- `make docker-build-testserver` / `make docker-push-testserver` — build/push the test server image

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] `make test-parity` against baremetal cluster (in progress)
- [ ] Add GitHub Actions workflow (follow-up PR)