### PR TITLE
Add daily build workflows for parity test images

### DIFF
--- a/.github/workflows/build-testserver.yml
+++ b/.github/workflows/build-testserver.yml
@@ -1,0 +1,51 @@
+name: Build Test Server Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'test/testserver/**'
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: bapalm/tls-test-server
+
+jobs:
+  build:
+    name: Build and Push Test Server
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v7
+        with:
+          context: test/testserver
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha,scope=testserver
+          cache-to: type=gha,mode=max,scope=testserver

--- a/.github/workflows/build-tls-scanner.yml
+++ b/.github/workflows/build-tls-scanner.yml
@@ -1,0 +1,54 @@
+name: Build TLS Scanner Image
+
+on:
+  schedule:
+    - cron: '23 4 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: bapalm/tls-scanner
+
+jobs:
+  build:
+    name: Build and Push TLS Scanner
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout upstream tls-scanner
+        uses: actions/checkout@v6
+        with:
+          repository: openshift/tls-scanner
+
+      - name: Patch Dockerfile.local for Fedora base
+        run: |
+          sed -i 's|registry.access.redhat.com/ubi9/ubi:latest|registry.fedoraproject.org/fedora:latest|' Dockerfile.local
+          grep -q 'registry.fedoraproject.org/fedora:latest' Dockerfile.local || { echo "FATAL: sed replacement failed — UBI9 base image line not found in Dockerfile.local"; exit 1; }
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.local
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha,scope=tls-scanner
+          cache-to: type=gha,mode=max,scope=tls-scanner


### PR DESCRIPTION
## Summary

- Add `build-testserver.yml` workflow to build `quay.io/bapalm/tls-test-server:latest` (multi-arch: amd64, arm64)
  - Triggers: daily at 04:17 UTC, push to main when `test/testserver/**` changes, manual dispatch
  - Builds from `test/testserver/Dockerfile` (scratch-based, ~7MB image)

- Add `build-tls-scanner.yml` workflow to build `quay.io/bapalm/tls-scanner:latest` (multi-arch: amd64, arm64)
  - Triggers: daily at 04:23 UTC, manual dispatch
  - Clones upstream `openshift/tls-scanner`, auto-detects Go version from go.mod
  - Uses Fedora base with testssl.sh, oc client, and util-linux (hexdump)

## Test plan

- [ ] Trigger `build-testserver.yml` via workflow_dispatch and verify image pushed to quay.io
- [ ] Trigger `build-tls-scanner.yml` via workflow_dispatch and verify image pushed to quay.io