### PR TITLE
Detect TLS versions behind mTLS endpoints

### DIFF
--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -355,6 +355,15 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 		var failReason tlscheck.FailureReason
 		if result != nil {
 			failReason = result.FailureReason
+
+			// Populate TLS version info even on error (e.g. mTLS detected versions)
+			cr.Status.TLSVersions = securityv1alpha1.TLSVersionSupport{
+				SSL30: result.SupportsSSL30,
+				TLS10: result.SupportsTLS10,
+				TLS11: result.SupportsTLS11,
+				TLS12: result.SupportsTLS12,
+				TLS13: result.SupportsTLS13,
+			}
 		}
 
 		cr.Status.ComplianceStatus = failureReasonToComplianceStatus(failReason)

--- a/pkg/tlscheck/checker.go
+++ b/pkg/tlscheck/checker.go
@@ -95,6 +95,10 @@ func (c *TLSChecker) CheckEndpoint(ctx context.Context, host string, port int) (
 			if cert != nil && result.Certificate == nil {
 				result.Certificate = cert
 			}
+		} else if supported && err != nil {
+			// mTLS: version is supported but handshake failed due to client cert requirement
+			anySuccess = true
+			lastErrors = append(lastErrors, err)
 		} else if err != nil {
 			lastErrors = append(lastErrors, err)
 		}
@@ -110,6 +114,12 @@ func (c *TLSChecker) CheckEndpoint(ctx context.Context, host string, port int) (
 	if !anySuccess {
 		result.FailureReason = classifyFailure(lastErrors)
 		return result, fmt.Errorf("could not establish TLS connection to %s on any TLS version", addr)
+	}
+
+	// mTLS: we detected supported versions but no connection fully succeeded
+	if len(lastErrors) > 0 && classifyFailure(lastErrors) == FailureReasonMutualTLSRequired {
+		result.FailureReason = FailureReasonMutualTLSRequired
+		return result, fmt.Errorf("endpoint %s requires mutual TLS (client certificate)", addr)
 	}
 
 	return result, nil
@@ -174,6 +184,12 @@ func classifyFailure(errs []error) FailureReason {
 	return FailureReasonUnreachable
 }
 
+func isMTLSError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "certificate required") ||
+		strings.Contains(msg, "bad certificate")
+}
+
 // tryTLSVersion attempts to connect with a specific TLS version
 func (c *TLSChecker) tryTLSVersion(ctx context.Context, addr, serverName string, version uint16) (supported bool, cipherSuite string, curveName string, cert *CertificateDetails, err error) {
 	dialer := &net.Dialer{
@@ -189,6 +205,10 @@ func (c *TLSChecker) tryTLSVersion(ctx context.Context, addr, serverName string,
 
 	conn, err := tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
 	if err != nil {
+		// mTLS: server requires a client certificate but we proved it speaks this TLS version
+		if isMTLSError(err) {
+			return true, "", "", nil, err
+		}
 		return false, "", "", nil, err
 	}
 	defer conn.Close() //nolint:errcheck


### PR DESCRIPTION
## Summary

- When an endpoint requires mutual TLS (client certificate), the operator now correctly reports which TLS versions the server supports
- Previously, mTLS endpoints showed all TLS version bools as false because the handshake failed before version negotiation completed
- The fix recognizes that a "certificate required" or "bad certificate" error proves the server speaks that TLS version

## Changes

- `pkg/tlscheck/checker.go`: `tryTLSVersion` returns `supported=true` when the error is an mTLS rejection; `CheckEndpoint` tracks these as successful version detections while still reporting `FailureReasonMutualTLSRequired`
- `internal/controller/endpoint_controller.go`: populate `TLSVersions` on the error path when the result contains version information

## How it was found

Parity testing against the upstream `openshift/tls-scanner` (which uses testssl.sh) showed the scanner correctly reported TLS 1.2 + 1.3 on an mTLS endpoint, while the operator only reported TLS 1.3.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] Deploy to cluster with mTLS endpoint and verify TLS versions are populated in the TLSComplianceReport