### PR TITLE
Remove separate controller-runtime dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
-      controller-runtime:
-        patterns:
-          - "sigs.k8s.io/controller-runtime"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
- Removes the separate `controller-runtime` dependabot group that was overriding the `kubernetes` group's `sigs.k8s.io/*` pattern
- controller-runtime will now be grouped with all other k8s dependencies in a single PR, preventing version mismatch build failures

## Related PRs
- https://github.com/sebrandon1/imagecertinfo-operator/pull/103
- https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1462
- https://github.com/redhat-best-practices-for-k8s/checks-qe/pull/29