### PR TITLE
Fix MaxConcurrentReconciles to use --workers flag

### DIFF
--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -736,7 +736,7 @@ func (r *EndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Service{}).
 		Named("endpoint").
-		WithOptions(controller.Options{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.Workers}).
 		Watches(&networkingv1.Ingress{}, handler.EnqueueRequestsFromMapFunc(
 			func(ctx context.Context, obj client.Object) []ctrl.Request {
 				ing, ok := obj.(*networkingv1.Ingress)


### PR DESCRIPTION
## Summary
- The --workers flag was accepted and logged but never passed to the controller's MaxConcurrentReconciles option
- The reconciler always ran with the default of 1 concurrent worker regardless of the flag value
- One-line fix: pass r.Workers into controller.Options{}

Fixes #112