### PR TITLE
Use manager context for async TLS check goroutines

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -269,6 +269,9 @@ func main() {
 		"maxRetries", maxRetries,
 		"retryBackoff", retryBackoff)
 
+	// Set up signal-aware context for the operator lifecycle
+	ctx := ctrl.SetupSignalHandler()
+
 	// Set up the endpoint controller
 	endpointReconciler := &controller.EndpointReconciler{
 		Client:            mgr.GetClient(),
@@ -283,6 +286,7 @@ func main() {
 		Workers:           workers,
 		MaxRetries:        maxRetries,
 		RetryBackoff:      retryBackoff,
+		ManagerCtx:        ctx,
 	}
 
 	if err = endpointReconciler.SetupWithManager(mgr); err != nil {
@@ -291,7 +295,6 @@ func main() {
 	}
 
 	// Start background loops
-	ctx := ctrl.SetupSignalHandler()
 	endpointReconciler.StartPeriodicScan(ctx, scanInterval)
 	endpointReconciler.StartCleanupLoop(ctx, cleanupInterval)
 	if profileFetcher != nil {

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -79,6 +79,7 @@ type EndpointReconciler struct {
 	Workers           int
 	MaxRetries        int
 	RetryBackoff      time.Duration
+	ManagerCtx        context.Context
 }
 
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
@@ -265,8 +266,11 @@ func (r *EndpointReconciler) processEndpoint(ctx context.Context, ep endpoint.En
 				fmt.Sprintf("Discovered TLS endpoint %s from %s %s/%s", hostPort(ep.Host, ep.Port), ep.SourceKind, ep.SourceNamespace, ep.SourceName))
 		}
 
-		// Launch async TLS check using the caller's context for cancellation
-		go r.performTLSCheck(ctx, crName, ep.Host, int(ep.Port))
+		checkCtx := r.ManagerCtx
+		if checkCtx == nil {
+			checkCtx = context.Background()
+		}
+		go r.performTLSCheck(checkCtx, crName, ep.Host, int(ep.Port))
 
 		return nil
 	} else if err != nil {


### PR DESCRIPTION
## Summary
- The performTLSCheck goroutine in processEndpoint was using the request-scoped context, which gets cancelled when the reconciler returns
- This could interrupt in-flight TLS checks, leaving CRs with stale or partial status
- Use the manager-scoped context instead, which is only cancelled on operator shutdown
- The context is set as a field on the reconciler struct at construction time, with a context.Background() fallback for tests

## Changes
- Added `ManagerCtx` field to `EndpointReconciler` struct
- Set it from the signal handler context in `cmd/main.go` at construction time
- Use it (with `context.Background()` fallback) for the `performTLSCheck` goroutine

Fixes #115