### PR TITLE
Add test coverage for kubectl-tlsreport plugin and export edge cases

### DIFF
--- a/cmd/kubectl-tlsreport/main_test.go
+++ b/cmd/kubectl-tlsreport/main_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+func TestNewRootCmd_Structure(t *testing.T) {
+	cmd := newRootCmd()
+
+	if cmd.Use != "kubectl-tlsreport [csv|json|junit]" {
+		t.Errorf("unexpected Use: %s", cmd.Use)
+	}
+
+	if cmd.RunE == nil {
+		t.Error("expected RunE to be set")
+	}
+
+	summary := cmd.Commands()
+	found := false
+	for _, sub := range summary {
+		if sub.Use == "summary" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected summary subcommand")
+	}
+}
+
+func TestNewRootCmd_Flags(t *testing.T) {
+	cmd := newRootCmd()
+
+	tests := []struct {
+		flag      string
+		shorthand string
+	}{
+		{"namespace", "n"},
+		{"status", ""},
+		{"source", ""},
+	}
+
+	for _, tt := range tests {
+		f := cmd.PersistentFlags().Lookup(tt.flag)
+		if f == nil {
+			t.Errorf("expected persistent flag %q", tt.flag)
+			continue
+		}
+		if tt.shorthand != "" && f.Shorthand != tt.shorthand {
+			t.Errorf("flag %q: expected shorthand %q, got %q", tt.flag, tt.shorthand, f.Shorthand)
+		}
+	}
+}
+
+func TestRunExport_InvalidFormat(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"xml"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+	if err.Error() != "unknown format: xml (supported: csv, json, junit)" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunExport_ValidFormats(t *testing.T) {
+	for _, format := range []string{"csv", "json", "junit"} {
+		cmd := newRootCmd()
+		cmd.SetArgs([]string{format})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Skipf("format %q: skipping (no kubeconfig available)", format)
+		}
+		if err.Error() == "unknown format: "+format+" (supported: csv, json, junit)" {
+			t.Errorf("format %q should be valid but was rejected", format)
+		}
+	}
+}
+
+func TestNewSummaryCmd(t *testing.T) {
+	cmd := newSummaryCmd()
+
+	if cmd.Use != "summary" {
+		t.Errorf("unexpected Use: %s", cmd.Use)
+	}
+	if cmd.RunE == nil {
+		t.Error("expected RunE to be set")
+	}
+}
+
+func TestSchemeRegistration(t *testing.T) {
+	if scheme == nil {
+		t.Fatal("scheme should not be nil")
+	}
+
+	gvk := securityv1alpha1.GroupVersion.WithKind("TLSComplianceReport")
+	if !scheme.Recognizes(gvk) {
+		t.Errorf("scheme should recognize %v", gvk)
+	}
+
+	gvk = securityv1alpha1.GroupVersion.WithKind("TLSComplianceTarget")
+	if !scheme.Recognizes(gvk) {
+		t.Errorf("scheme should recognize %v", gvk)
+	}
+}

--- a/pkg/export/csv_test.go
+++ b/pkg/export/csv_test.go
@@ -18,6 +18,7 @@ package export
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -164,5 +165,206 @@ func TestWriteCSV_MultipleReports(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
 	if len(lines) != 3 {
 		t.Fatalf("expected 3 lines (header + 2 rows), got %d", len(lines))
+	}
+}
+
+func TestWriteCSV_AllComplianceStatuses(t *testing.T) {
+	statuses := []securityv1alpha1.ComplianceStatus{
+		securityv1alpha1.ComplianceStatusCompliant,
+		securityv1alpha1.ComplianceStatusNonCompliant,
+		securityv1alpha1.ComplianceStatusWarning,
+		securityv1alpha1.ComplianceStatusUnreachable,
+		securityv1alpha1.ComplianceStatusTimeout,
+		securityv1alpha1.ComplianceStatusClosed,
+		securityv1alpha1.ComplianceStatusFiltered,
+		securityv1alpha1.ComplianceStatusNoTLS,
+		securityv1alpha1.ComplianceStatusMutualTLSRequired,
+		securityv1alpha1.ComplianceStatusPending,
+		securityv1alpha1.ComplianceStatusUnknown,
+	}
+
+	var reports []securityv1alpha1.TLSComplianceReport
+	for i, s := range statuses {
+		reports = append(reports, securityv1alpha1.TLSComplianceReport{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            fmt.Sprintf("svc%d.test", i),
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "test",
+				SourceName:      fmt.Sprintf("svc%d", i),
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: s,
+			},
+		})
+	}
+
+	var buf bytes.Buffer
+	err := WriteCSV(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	for _, s := range statuses {
+		if !strings.Contains(output, string(s)) {
+			t.Errorf("expected CSV to contain status %q", s)
+		}
+	}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != len(statuses)+1 {
+		t.Fatalf("expected %d lines, got %d", len(statuses)+1, len(lines))
+	}
+}
+
+func TestWriteCSV_AllSourceKinds(t *testing.T) {
+	kinds := []securityv1alpha1.SourceKind{
+		securityv1alpha1.SourceKindService,
+		securityv1alpha1.SourceKindIngress,
+		securityv1alpha1.SourceKindRoute,
+		securityv1alpha1.SourceKindTarget,
+		securityv1alpha1.SourceKindPod,
+	}
+
+	var reports []securityv1alpha1.TLSComplianceReport
+	for i, k := range kinds {
+		reports = append(reports, securityv1alpha1.TLSComplianceReport{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            fmt.Sprintf("ep%d.test", i),
+				Port:            443,
+				SourceKind:      k,
+				SourceNamespace: "test",
+				SourceName:      fmt.Sprintf("ep%d", i),
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+			},
+		})
+	}
+
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	for _, k := range kinds {
+		if !strings.Contains(output, string(k)) {
+			t.Errorf("expected CSV to contain source kind %q", k)
+		}
+	}
+}
+
+func TestWriteCSV_KeyExchangeTypes(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "multi-ke.test",
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "test",
+				SourceName:      "multi-ke",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				KeyExchangeTypes: map[string]string{
+					"TLS 1.2": "ECDHE",
+					"TLS 1.3": "TLS13",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "ECDHE") {
+		t.Error("expected CSV to contain ECDHE")
+	}
+	if !strings.Contains(output, "TLS13") {
+		t.Error("expected CSV to contain TLS13")
+	}
+}
+
+func TestWriteCSV_SpecialCharacters(t *testing.T) {
+	expiry := metav1.NewTime(time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "svc-with-special.ns-with-dash",
+				Port:            8443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "ns-with-dash",
+				SourceName:      "svc-with-special",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				CertificateInfo: &securityv1alpha1.CertificateInfo{
+					Issuer:   "CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US",
+					NotAfter: &expiry,
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Let's Encrypt") {
+		t.Error("expected CSV to handle apostrophe in issuer")
+	}
+	if !strings.Contains(output, "ns-with-dash") {
+		t.Error("expected CSV to handle dashes in namespace")
+	}
+}
+
+func TestWriteCSV_AllTLSVersionCombinations(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "all-versions.test",
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "test",
+				SourceName:      "all-versions",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusNonCompliant,
+				TLSVersions: securityv1alpha1.TLSVersionSupport{
+					SSL30: true,
+					TLS10: true,
+					TLS11: true,
+					TLS12: true,
+					TLS13: true,
+				},
+				ForwardSecrecy: true,
+				QuantumReady:   true,
+				PQCReadiness:   securityv1alpha1.PQCReadinessPQCReady,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	row := lines[1]
+	for _, field := range []string{"true", "NonCompliant", "PQCReady"} {
+		if !strings.Contains(row, field) {
+			t.Errorf("expected row to contain %q", field)
+		}
 	}
 }

--- a/pkg/export/json_test.go
+++ b/pkg/export/json_test.go
@@ -19,6 +19,7 @@ package export
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -273,5 +274,138 @@ func TestWriteJSON_RoundTrip(t *testing.T) {
 	}
 	if reparsed[0].Grade != "B" {
 		t.Errorf("grade mismatch after round-trip: %s", reparsed[0].Grade)
+	}
+}
+
+func TestWriteJSON_AllComplianceStatuses(t *testing.T) {
+	statuses := []securityv1alpha1.ComplianceStatus{
+		securityv1alpha1.ComplianceStatusCompliant,
+		securityv1alpha1.ComplianceStatusNonCompliant,
+		securityv1alpha1.ComplianceStatusWarning,
+		securityv1alpha1.ComplianceStatusUnreachable,
+		securityv1alpha1.ComplianceStatusTimeout,
+		securityv1alpha1.ComplianceStatusClosed,
+		securityv1alpha1.ComplianceStatusFiltered,
+		securityv1alpha1.ComplianceStatusNoTLS,
+		securityv1alpha1.ComplianceStatusMutualTLSRequired,
+		securityv1alpha1.ComplianceStatusPending,
+		securityv1alpha1.ComplianceStatusUnknown,
+	}
+
+	var reports []securityv1alpha1.TLSComplianceReport
+	for i, s := range statuses {
+		reports = append(reports, securityv1alpha1.TLSComplianceReport{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            fmt.Sprintf("svc%d.test", i),
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "test",
+				SourceName:      fmt.Sprintf("svc%d", i),
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: s,
+			},
+		})
+	}
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result []JSONReport
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(result) != len(statuses) {
+		t.Fatalf("expected %d items, got %d", len(statuses), len(result))
+	}
+
+	for i, s := range statuses {
+		if result[i].Compliance != string(s) {
+			t.Errorf("item %d: expected compliance %q, got %q", i, s, result[i].Compliance)
+		}
+	}
+}
+
+func TestWriteJSON_KeyExchangeTypes(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "multi-ke.test",
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "test",
+				SourceName:      "multi-ke",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				KeyExchangeTypes: map[string]string{
+					"TLS 1.2": "ECDHE",
+					"TLS 1.3": "TLS13",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result []JSONReport
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	ke := result[0].KeyExchangeTypes
+	if ke["TLS 1.2"] != "ECDHE" {
+		t.Errorf("expected TLS 1.2 key exchange ECDHE, got %s", ke["TLS 1.2"])
+	}
+	if ke["TLS 1.3"] != "TLS13" {
+		t.Errorf("expected TLS 1.3 key exchange TLS13, got %s", ke["TLS 1.3"])
+	}
+}
+
+func TestWriteJSON_PQCReadinessValues(t *testing.T) {
+	pqcValues := []securityv1alpha1.PQCReadiness{
+		securityv1alpha1.PQCReadinessPQCReady,
+		securityv1alpha1.PQCReadinessTLS13Capable,
+		securityv1alpha1.PQCReadinessLegacyTLS,
+		securityv1alpha1.PQCReadinessNoPQC,
+	}
+
+	var reports []securityv1alpha1.TLSComplianceReport
+	for i, pqc := range pqcValues {
+		reports = append(reports, securityv1alpha1.TLSComplianceReport{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            fmt.Sprintf("pqc%d.test", i),
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "test",
+				SourceName:      fmt.Sprintf("pqc%d", i),
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     pqc,
+			},
+		})
+	}
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result []JSONReport
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	for i, pqc := range pqcValues {
+		if result[i].PQCReadiness != string(pqc) {
+			t.Errorf("item %d: expected PQCReadiness %q, got %q", i, pqc, result[i].PQCReadiness)
+		}
 	}
 }

--- a/pkg/export/summary_test.go
+++ b/pkg/export/summary_test.go
@@ -357,3 +357,63 @@ func TestWriteSummary_Empty(t *testing.T) {
 		t.Error("expected 0.0% compliance rate")
 	}
 }
+
+func TestComputeSummary_CertExpiryBoundaries(t *testing.T) {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	makeReport := func(daysFromNow int) securityv1alpha1.TLSComplianceReport {
+		expiry := metav1.NewTime(now.AddDate(0, 0, daysFromNow))
+		return securityv1alpha1.TLSComplianceReport{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:       "test.example",
+				Port:       443,
+				SourceKind: securityv1alpha1.SourceKindService,
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				CertificateInfo: &securityv1alpha1.CertificateInfo{
+					NotAfter: &expiry,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		daysFromNow     int
+		wantExpired     int
+		wantExpiring7d  int
+		wantExpiring30d int
+		wantExpiring90d int
+	}{
+		{"expired yesterday", -1, 1, 0, 0, 0},
+		{"expires today", 0, 0, 1, 0, 0},
+		{"expires in 1 day", 1, 0, 1, 0, 0},
+		{"expires in 6 days", 6, 0, 1, 0, 0},
+		{"expires in 8 days", 8, 0, 0, 1, 0},
+		{"expires in 29 days", 29, 0, 0, 1, 0},
+		{"expires in 31 days", 31, 0, 0, 0, 1},
+		{"expires in 89 days", 89, 0, 0, 0, 1},
+		{"expires in 91 days", 91, 0, 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reports := []securityv1alpha1.TLSComplianceReport{makeReport(tt.daysFromNow)}
+			summary := ComputeSummary(reports, now)
+
+			if summary.CertExpired != tt.wantExpired {
+				t.Errorf("CertExpired: got %d, want %d", summary.CertExpired, tt.wantExpired)
+			}
+			if summary.CertExpiring7d != tt.wantExpiring7d {
+				t.Errorf("CertExpiring7d: got %d, want %d", summary.CertExpiring7d, tt.wantExpiring7d)
+			}
+			if summary.CertExpiring30d != tt.wantExpiring30d {
+				t.Errorf("CertExpiring30d: got %d, want %d", summary.CertExpiring30d, tt.wantExpiring30d)
+			}
+			if summary.CertExpiring90d != tt.wantExpiring90d {
+				t.Errorf("CertExpiring90d: got %d, want %d", summary.CertExpiring90d, tt.wantExpiring90d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add CLI tests for command structure, flags, subcommands, invalid format handling, and scheme registration
- Add CSV/JSON tests for all 11 compliance statuses, all 5 source kinds, key exchange types, special characters, PQC readiness values
- Add summary boundary tests for certificate expiry at each bucket threshold

## Coverage improvements
- `cmd/kubectl-tlsreport`: 0% -> 62.8%
- `pkg/export`: 82.1% -> 88.1%

Fixes #125