### PR TITLE
Add missing environment variable overrides for all configuration flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ kubectl apply -f dist/install.yaml
 | Guide | Description |
 |-------|-------------|
 | [Installation](docs/installation.md) | Deploy to your cluster in one command |
+| [Configuration](docs/configuration.md) | All flags, environment variables, defaults, and tuning guidance |
 | [Viewing Reports](docs/viewing-reports.md) | Understand compliance status, cipher grades, and certificate info |
 | [Custom Targets](docs/custom-targets.md) | Scan arbitrary external hosts with `TLSComplianceTarget` |
 | [Exporting Reports](docs/exporting-reports.md) | CSV, JSON, and JUnit XML export for CI/CD |
@@ -226,10 +227,17 @@ container args is inconvenient.
 | Environment Variable | Flag | Default |
 |---------------------|------|---------|
 | `TLS_COMPLIANCE_SCAN_INTERVAL` | `--scan-interval` | `1h` |
+| `TLS_COMPLIANCE_CLEANUP_INTERVAL` | `--cleanup-interval` | `5m` |
 | `TLS_COMPLIANCE_CHECK_TIMEOUT` | `--tls-check-timeout` | `5s` |
 | `TLS_COMPLIANCE_RATE_LIMIT` | `--rate-limit` | `10` |
+| `TLS_COMPLIANCE_RATE_BURST` | `--rate-burst` | `20` |
 | `TLS_COMPLIANCE_WORKERS` | `--workers` | `5` |
+| `TLS_COMPLIANCE_INCLUDE_NAMESPACES` | `--include-namespaces` | `""` |
 | `TLS_COMPLIANCE_EXCLUDE_NAMESPACES` | `--exclude-namespaces` | `""` |
+| `TLS_COMPLIANCE_CERT_EXPIRY_WARNING_DAYS` | `--cert-expiry-warning-days` | `30` |
+| `TLS_COMPLIANCE_PROFILE_REFRESH_INTERVAL` | `--profile-refresh-interval` | `5m` |
+| `TLS_COMPLIANCE_MAX_RETRIES` | `--max-retries` | `3` |
+| `TLS_COMPLIANCE_RETRY_BACKOFF` | `--retry-backoff` | `30s` |
 
 Example: set scan interval via environment variable in a Deployment:
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -325,10 +325,17 @@ var envFlagMapping = []struct {
 	flagName string
 }{
 	{"TLS_COMPLIANCE_SCAN_INTERVAL", "scan-interval"},
+	{"TLS_COMPLIANCE_CLEANUP_INTERVAL", "cleanup-interval"},
 	{"TLS_COMPLIANCE_CHECK_TIMEOUT", "tls-check-timeout"},
 	{"TLS_COMPLIANCE_RATE_LIMIT", "rate-limit"},
+	{"TLS_COMPLIANCE_RATE_BURST", "rate-burst"},
 	{"TLS_COMPLIANCE_WORKERS", "workers"},
+	{"TLS_COMPLIANCE_INCLUDE_NAMESPACES", "include-namespaces"},
 	{"TLS_COMPLIANCE_EXCLUDE_NAMESPACES", "exclude-namespaces"},
+	{"TLS_COMPLIANCE_CERT_EXPIRY_WARNING_DAYS", "cert-expiry-warning-days"},
+	{"TLS_COMPLIANCE_PROFILE_REFRESH_INTERVAL", "profile-refresh-interval"},
+	{"TLS_COMPLIANCE_MAX_RETRIES", "max-retries"},
+	{"TLS_COMPLIANCE_RETRY_BACKOFF", "retry-backoff"},
 }
 
 // resolveEnvConfig applies environment variable overrides to flags that were not
@@ -380,7 +387,7 @@ func resolveEnvConfig(fs *flag.FlagSet, lookupEnv func(string) (string, bool)) [
 // validateEnvValue performs type-appropriate validation for known flag types.
 func validateEnvValue(flagName, value string) error {
 	switch flagName {
-	case "scan-interval", "tls-check-timeout":
+	case "scan-interval", "cleanup-interval", "tls-check-timeout", "profile-refresh-interval", "retry-backoff":
 		if _, err := time.ParseDuration(value); err != nil {
 			return fmt.Errorf("invalid duration: %w", err)
 		}
@@ -388,14 +395,25 @@ func validateEnvValue(flagName, value string) error {
 		if _, err := strconv.ParseFloat(value, 64); err != nil {
 			return fmt.Errorf("invalid float: %w", err)
 		}
+	case "rate-burst":
+		return validateIntRange(value, 1, 1000)
+	case "cert-expiry-warning-days":
+		return validateIntRange(value, 1, 365)
 	case "workers":
-		v, err := strconv.Atoi(value)
-		if err != nil {
-			return fmt.Errorf("invalid integer: %w", err)
-		}
-		if v < 1 || v > 50 {
-			return fmt.Errorf("must be between 1 and 50, got %d", v)
-		}
+		return validateIntRange(value, 1, 50)
+	case "max-retries":
+		return validateIntRange(value, 0, 10)
+	}
+	return nil
+}
+
+func validateIntRange(value string, min, max int) error {
+	v, err := strconv.Atoi(value)
+	if err != nil {
+		return fmt.Errorf("invalid integer: %w", err)
+	}
+	if v < min || v > max {
+		return fmt.Errorf("must be between %d and %d, got %d", min, max, v)
 	}
 	return nil
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,99 @@
+# Configuration Reference
+
+The tls-compliance-operator is configured via command-line flags. Every flag
+can also be set via an environment variable, which is useful when deploying
+with Helm or kustomize overlays where modifying container args is inconvenient.
+
+**Precedence:** CLI flag > environment variable > default value.
+
+If a flag is set on the command line, its environment variable is ignored.
+
+## Scanning
+
+| Flag | Env Var | Type | Default | Description |
+|------|---------|------|---------|-------------|
+| `--scan-interval` | `TLS_COMPLIANCE_SCAN_INTERVAL` | duration | `1h` | How often the operator re-checks all known TLS endpoints. Each cycle scans every Service, Ingress, Route, and Pod endpoint. Shorter intervals give faster detection but increase API server and network load. |
+| `--cleanup-interval` | `TLS_COMPLIANCE_CLEANUP_INTERVAL` | duration | `5m` | How often the operator removes TLSComplianceReport CRs whose source resource (Service, Ingress, Route) has been deleted. |
+| `--tls-check-timeout` | `TLS_COMPLIANCE_CHECK_TIMEOUT` | duration | `5s` | Timeout for each individual TLS connection attempt. The operator probes TLS 1.0, 1.1, 1.2, 1.3, and SSLv3 sequentially, so worst-case time per endpoint is roughly 5x this value. Increase on high-latency networks. |
+| `--workers` | `TLS_COMPLIANCE_WORKERS` | int | `5` | Number of concurrent goroutines used during periodic scans. Range: 1-50. Higher values scan faster but use more CPU and network. This also controls `MaxConcurrentReconciles` for the controller work queue. |
+
+## Rate Limiting
+
+| Flag | Env Var | Type | Default | Description |
+|------|---------|------|---------|-------------|
+| `--rate-limit` | `TLS_COMPLIANCE_RATE_LIMIT` | float | `10` | Maximum TLS checks per second (token bucket rate). Controls how aggressively the operator probes endpoints. On large clusters, increase this alongside `--workers` for faster scans. |
+| `--rate-burst` | `TLS_COMPLIANCE_RATE_BURST` | int | `20` | Token bucket burst size. Allows short bursts above the rate limit. Range: 1-1000. |
+
+## Namespace Filtering
+
+| Flag | Env Var | Type | Default | Description |
+|------|---------|------|---------|-------------|
+| `--include-namespaces` | `TLS_COMPLIANCE_INCLUDE_NAMESPACES` | string | `""` | Comma-separated list of namespaces to exclusively monitor. When set, only endpoints in these namespaces are scanned. Overrides `--exclude-namespaces`. |
+| `--exclude-namespaces` | `TLS_COMPLIANCE_EXCLUDE_NAMESPACES` | string | `""` | Comma-separated list of namespaces to skip. Ignored if `--include-namespaces` is set. |
+
+If neither flag is set, all namespaces are scanned.
+
+## Certificate Monitoring
+
+| Flag | Env Var | Type | Default | Description |
+|------|---------|------|---------|-------------|
+| `--cert-expiry-warning-days` | `TLS_COMPLIANCE_CERT_EXPIRY_WARNING_DAYS` | int | `30` | Number of days before certificate expiry to emit a `CertificateExpiring` warning event. Range: 1-365. Set lower for environments with short-lived certificates (e.g., cert-manager with 90-day certs). |
+
+## Retry Behavior
+
+| Flag | Env Var | Type | Default | Description |
+|------|---------|------|---------|-------------|
+| `--max-retries` | `TLS_COMPLIANCE_MAX_RETRIES` | int | `3` | Maximum number of retries for transient TLS check failures (Timeout, Unreachable). Range: 0-10. Set to 0 to disable retries entirely. Each retry uses exponential backoff. |
+| `--retry-backoff` | `TLS_COMPLIANCE_RETRY_BACKOFF` | duration | `30s` | Base backoff duration between retries. Actual delay is `base * 2^attempt` (30s, 60s, 120s for the default). On clusters with many unreachable endpoints, increasing this reduces wasted checks. |
+
+## OpenShift Integration
+
+| Flag | Env Var | Type | Default | Description |
+|------|---------|------|---------|-------------|
+| `--profile-refresh-interval` | `TLS_COMPLIANCE_PROFILE_REFRESH_INTERVAL` | duration | `5m` | How often to re-fetch OpenShift TLS security profile configuration (APIServer, IngressController, KubeletConfig). Only used when running on OpenShift. Ignored on vanilla Kubernetes. |
+
+## Infrastructure
+
+These flags are standard controller-runtime/kubebuilder flags. They do not have
+environment variable overrides.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--metrics-bind-address` | string | `0` | Address for the metrics endpoint. Use `:8443` for HTTPS, `:8080` for HTTP, or `0` to disable. |
+| `--health-probe-bind-address` | string | `:8081` | Address for liveness and readiness probes (`/healthz` and `/readyz`). |
+| `--leader-elect` | bool | `false` | Enable leader election for HA deployments. Only one replica processes events at a time. |
+| `--metrics-secure` | bool | `true` | Serve metrics over HTTPS. Set to `false` for HTTP. |
+| `--enable-http2` | bool | `false` | Enable HTTP/2 for metrics and webhook servers. Disabled by default to mitigate HTTP/2 rapid reset CVEs. |
+| `--metrics-cert-path` | string | `""` | Directory containing the metrics server TLS certificate. |
+| `--metrics-cert-name` | string | `tls.crt` | Filename of the metrics server certificate. |
+| `--metrics-cert-key` | string | `tls.key` | Filename of the metrics server private key. |
+| `--webhook-cert-path` | string | `""` | Directory containing the webhook server TLS certificate. |
+| `--webhook-cert-name` | string | `tls.crt` | Filename of the webhook certificate. |
+| `--webhook-cert-key` | string | `tls.key` | Filename of the webhook private key. |
+
+## Examples
+
+### Environment variables in a Deployment
+
+```yaml
+env:
+- name: TLS_COMPLIANCE_SCAN_INTERVAL
+  value: "30m"
+- name: TLS_COMPLIANCE_WORKERS
+  value: "10"
+- name: TLS_COMPLIANCE_EXCLUDE_NAMESPACES
+  value: "kube-system,openshift-monitoring"
+- name: TLS_COMPLIANCE_CERT_EXPIRY_WARNING_DAYS
+  value: "14"
+```
+
+### CLI flags in container args
+
+```yaml
+args:
+- --scan-interval=30m
+- --workers=10
+- --exclude-namespaces=kube-system,openshift-monitoring
+- --cert-expiry-warning-days=14
+- --leader-elect
+```


### PR DESCRIPTION
## Summary
- Add env var support for 7 flags that were missing overrides: cleanup-interval, rate-burst, include-namespaces, cert-expiry-warning-days, profile-refresh-interval, max-retries, retry-backoff
- Add type-appropriate validation (duration parsing, integer range checks) for the new mappings
- Follows the existing pattern in envFlagMapping and validateEnvValue

All flags now have corresponding `TLS_COMPLIANCE_*` environment variables.

Fixes #113