### PR TITLE
Add kubectl-tlsreport filters for PQC readiness and cert expiry

### DIFF
--- a/cmd/kubectl-tlsreport/main.go
+++ b/cmd/kubectl-tlsreport/main.go
@@ -63,6 +63,9 @@ Supported formats: csv (default), json, junit`,
 	rootCmd.PersistentFlags().StringVarP(&filterOpts.Namespace, "namespace", "n", "", "Filter by source namespace")
 	rootCmd.PersistentFlags().StringVar(&filterOpts.Status, "status", "", "Filter by compliance status (e.g. Compliant, NonCompliant)")
 	rootCmd.PersistentFlags().StringVar(&filterOpts.Source, "source", "", "Filter by source kind (e.g. Service, Ingress, Route, Pod)")
+	rootCmd.PersistentFlags().StringVar(&filterOpts.PQCStatus, "pqc-status", "", "Filter by PQC readiness (PQCReady, TLS13Capable, LegacyTLS, NoPQC)")
+	rootCmd.PersistentFlags().StringVar(&filterOpts.ExpiresWithin, "expires-within", "", "Show certs expiring within duration (e.g. 30d, 7d, 90d)")
+	rootCmd.PersistentFlags().BoolVar(&filterOpts.Expired, "expired", false, "Show only expired certificates")
 
 	rootCmd.AddCommand(newSummaryCmd())
 
@@ -94,7 +97,10 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	reports = export.FilterReports(reports, filterOpts)
+	reports, err = export.FilterReports(reports, filterOpts)
+	if err != nil {
+		return err
+	}
 
 	switch format {
 	case "csv":
@@ -114,7 +120,10 @@ func runSummary(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	reports = export.FilterReports(reports, filterOpts)
+	reports, err = export.FilterReports(reports, filterOpts)
+	if err != nil {
+		return err
+	}
 
 	return export.WriteSummary(os.Stdout, reports)
 }

--- a/cmd/kubectl-tlsreport/main_test.go
+++ b/cmd/kubectl-tlsreport/main_test.go
@@ -56,6 +56,9 @@ func TestNewRootCmd_Flags(t *testing.T) {
 		{"namespace", "n"},
 		{"status", ""},
 		{"source", ""},
+		{"pqc-status", ""},
+		{"expires-within", ""},
+		{"expired", ""},
 	}
 
 	for _, tt := range tests {

--- a/docs/exporting-reports.md
+++ b/docs/exporting-reports.md
@@ -36,7 +36,7 @@ kubectl tlsreport junit
 
 ## Filtering
 
-Filter by namespace, compliance status, or source kind:
+Filter by namespace, compliance status, source kind, PQC readiness, or certificate expiry:
 
 ```bash
 # Only reports from a specific namespace
@@ -47,7 +47,23 @@ kubectl tlsreport csv --status NonCompliant
 
 # Only Route-sourced endpoints
 kubectl tlsreport csv --source Route
+
+# Only endpoints not yet PQC-ready
+kubectl tlsreport csv --pqc-status LegacyTLS
+
+# Certificates expiring within 30 days
+kubectl tlsreport csv --expires-within 30d
+
+# Only expired certificates
+kubectl tlsreport csv --expired
+
+# Combine filters: non-PQC-ready services in production
+kubectl tlsreport json --source Service -n production --pqc-status TLS13Capable
 ```
+
+All filters use AND logic. PQC status values: `PQCReady`, `TLS13Capable`, `LegacyTLS`, `NoPQC`.
+The `--expires-within` flag accepts day-based durations (e.g. `7d`, `30d`, `90d`) or Go durations (e.g. `24h`).
+The `--expired` flag excludes endpoints without certificates.
 
 ## Summary View
 

--- a/pkg/export/filter.go
+++ b/pkg/export/filter.go
@@ -17,7 +17,10 @@ limitations under the License.
 package export
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
 )
@@ -30,26 +33,67 @@ type FilterOptions struct {
 	Status string
 	// Source filters by source kind (case-insensitive).
 	Source string
+	// PQCStatus filters by PQC readiness level (case-insensitive).
+	PQCStatus string
+	// ExpiresWithin filters to certificates expiring within a duration (e.g. "30d", "7d").
+	ExpiresWithin string
+	// Expired filters to only expired certificates.
+	Expired bool
+}
+
+// IsEmpty returns true if no filters are set.
+func (o FilterOptions) IsEmpty() bool {
+	return o.Namespace == "" && o.Status == "" && o.Source == "" &&
+		o.PQCStatus == "" && o.ExpiresWithin == "" && !o.Expired
 }
 
 // FilterReports returns the subset of reports matching all non-empty filter criteria.
 // Filters are combined with AND logic. Empty filters are pass-through.
-func FilterReports(reports []securityv1alpha1.TLSComplianceReport, opts FilterOptions) []securityv1alpha1.TLSComplianceReport {
-	if opts.Namespace == "" && opts.Status == "" && opts.Source == "" {
-		return reports
+// Returns an error if ExpiresWithin contains an unparseable duration.
+func FilterReports(reports []securityv1alpha1.TLSComplianceReport, opts FilterOptions) ([]securityv1alpha1.TLSComplianceReport, error) {
+	if opts.IsEmpty() {
+		return reports, nil
 	}
 
+	var expiresWithin time.Duration
+	if opts.ExpiresWithin != "" {
+		var err error
+		expiresWithin, err = ParseExpiresWithin(opts.ExpiresWithin)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --expires-within value %q: %w", opts.ExpiresWithin, err)
+		}
+	}
+
+	now := time.Now()
 	filtered := make([]securityv1alpha1.TLSComplianceReport, 0, len(reports))
 	for i := range reports {
-		if matchesFilter(&reports[i], opts) {
+		if matchesFilter(&reports[i], opts, now, expiresWithin) {
 			filtered = append(filtered, reports[i])
 		}
 	}
 
-	return filtered
+	return filtered, nil
 }
 
-func matchesFilter(r *securityv1alpha1.TLSComplianceReport, opts FilterOptions) bool {
+// ParseExpiresWithin parses a duration string like "30d", "7d", or "90d" into a time.Duration.
+func ParseExpiresWithin(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+
+	if strings.HasSuffix(s, "d") {
+		days, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid day count: %w", err)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+
+	return time.ParseDuration(s)
+}
+
+func matchesFilter(r *securityv1alpha1.TLSComplianceReport, opts FilterOptions, now time.Time, expiresWithin time.Duration) bool {
 	if opts.Namespace != "" && r.Spec.SourceNamespace != opts.Namespace {
 		return false
 	}
@@ -58,6 +102,23 @@ func matchesFilter(r *securityv1alpha1.TLSComplianceReport, opts FilterOptions) 
 	}
 	if opts.Source != "" && !strings.EqualFold(string(r.Spec.SourceKind), opts.Source) {
 		return false
+	}
+	if opts.PQCStatus != "" && !strings.EqualFold(string(r.Status.PQCReadiness), opts.PQCStatus) {
+		return false
+	}
+	if opts.Expired {
+		if r.Status.CertificateInfo == nil || !r.Status.CertificateInfo.IsExpired {
+			return false
+		}
+	}
+	if opts.ExpiresWithin != "" {
+		if r.Status.CertificateInfo == nil || r.Status.CertificateInfo.NotAfter == nil {
+			return false
+		}
+		expiry := r.Status.CertificateInfo.NotAfter.Time
+		if expiry.Before(now) || expiry.After(now.Add(expiresWithin)) {
+			return false
+		}
 	}
 
 	return true

--- a/pkg/export/filter_test.go
+++ b/pkg/export/filter_test.go
@@ -18,6 +18,9 @@ package export
 
 import (
 	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
 )
@@ -65,7 +68,7 @@ func testReports() []securityv1alpha1.TLSComplianceReport {
 
 func TestFilterReports_EmptyFilters(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{})
+	filtered, _ := FilterReports(reports, FilterOptions{})
 
 	if len(filtered) != len(reports) {
 		t.Errorf("expected %d reports, got %d", len(reports), len(filtered))
@@ -74,7 +77,7 @@ func TestFilterReports_EmptyFilters(t *testing.T) {
 
 func TestFilterReports_ByNamespace(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{Namespace: "default"})
+	filtered, _ := FilterReports(reports, FilterOptions{Namespace: "default"})
 
 	if len(filtered) != 2 {
 		t.Fatalf("expected 2 reports in default namespace, got %d", len(filtered))
@@ -88,7 +91,7 @@ func TestFilterReports_ByNamespace(t *testing.T) {
 
 func TestFilterReports_ByStatus(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{Status: "NonCompliant"})
+	filtered, _ := FilterReports(reports, FilterOptions{Status: "NonCompliant"})
 
 	if len(filtered) != 1 {
 		t.Fatalf("expected 1 NonCompliant report, got %d", len(filtered))
@@ -100,7 +103,7 @@ func TestFilterReports_ByStatus(t *testing.T) {
 
 func TestFilterReports_ByStatusCaseInsensitive(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{Status: "noncompliant"})
+	filtered, _ := FilterReports(reports, FilterOptions{Status: "noncompliant"})
 
 	if len(filtered) != 1 {
 		t.Fatalf("expected 1 report, got %d", len(filtered))
@@ -109,7 +112,7 @@ func TestFilterReports_ByStatusCaseInsensitive(t *testing.T) {
 
 func TestFilterReports_BySource(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{Source: "Service"})
+	filtered, _ := FilterReports(reports, FilterOptions{Source: "Service"})
 
 	if len(filtered) != 1 {
 		t.Fatalf("expected 1 Service report, got %d", len(filtered))
@@ -121,7 +124,7 @@ func TestFilterReports_BySource(t *testing.T) {
 
 func TestFilterReports_BySourceCaseInsensitive(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{Source: "service"})
+	filtered, _ := FilterReports(reports, FilterOptions{Source: "service"})
 
 	if len(filtered) != 1 {
 		t.Fatalf("expected 1 report, got %d", len(filtered))
@@ -130,7 +133,7 @@ func TestFilterReports_BySourceCaseInsensitive(t *testing.T) {
 
 func TestFilterReports_CombinedFilters(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{
+	filtered, _ := FilterReports(reports, FilterOptions{
 		Namespace: "default",
 		Status:    "Compliant",
 	})
@@ -142,7 +145,7 @@ func TestFilterReports_CombinedFilters(t *testing.T) {
 
 func TestFilterReports_CombinedFiltersAllThree(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{
+	filtered, _ := FilterReports(reports, FilterOptions{
 		Namespace: "default",
 		Status:    "Compliant",
 		Source:    "Route",
@@ -158,7 +161,7 @@ func TestFilterReports_CombinedFiltersAllThree(t *testing.T) {
 
 func TestFilterReports_NoMatch(t *testing.T) {
 	reports := testReports()
-	filtered := FilterReports(reports, FilterOptions{Namespace: "nonexistent"})
+	filtered, _ := FilterReports(reports, FilterOptions{Namespace: "nonexistent"})
 
 	if len(filtered) != 0 {
 		t.Errorf("expected 0 reports, got %d", len(filtered))
@@ -166,9 +169,179 @@ func TestFilterReports_NoMatch(t *testing.T) {
 }
 
 func TestFilterReports_NilInput(t *testing.T) {
-	filtered := FilterReports(nil, FilterOptions{Namespace: "default"})
+	filtered, _ := FilterReports(nil, FilterOptions{Namespace: "default"})
 
 	if len(filtered) != 0 {
 		t.Errorf("expected 0 reports, got %d", len(filtered))
+	}
+}
+
+func TestFilterReports_ByPQCStatus(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "a.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{PQCReadiness: securityv1alpha1.PQCReadinessPQCReady},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "b.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{PQCReadiness: securityv1alpha1.PQCReadinessTLS13Capable},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "c.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{PQCReadiness: securityv1alpha1.PQCReadinessLegacyTLS},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{PQCStatus: "LegacyTLS"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 LegacyTLS report, got %d", len(filtered))
+	}
+	if filtered[0].Spec.Host != "c.test" {
+		t.Errorf("expected c.test, got %s", filtered[0].Spec.Host)
+	}
+}
+
+func TestFilterReports_ByPQCStatusCaseInsensitive(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "a.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{PQCReadiness: securityv1alpha1.PQCReadinessPQCReady},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{PQCStatus: "pqcready"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(filtered))
+	}
+}
+
+func TestFilterReports_ByExpired(t *testing.T) {
+	now := time.Now()
+	expired := metav1.NewTime(now.Add(-24 * time.Hour))
+	valid := metav1.NewTime(now.Add(30 * 24 * time.Hour))
+
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "expired.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{NotAfter: &expired, IsExpired: true},
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "valid.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{NotAfter: &valid},
+			},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "nocert.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{Expired: true})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 expired report, got %d", len(filtered))
+	}
+	if filtered[0].Spec.Host != "expired.test" {
+		t.Errorf("expected expired.test, got %s", filtered[0].Spec.Host)
+	}
+}
+
+func TestFilterReports_ByExpiresWithin(t *testing.T) {
+	now := time.Now()
+	expiring5d := metav1.NewTime(now.Add(5 * 24 * time.Hour))
+	expiring60d := metav1.NewTime(now.Add(60 * 24 * time.Hour))
+	expired := metav1.NewTime(now.Add(-24 * time.Hour))
+
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "soon.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{NotAfter: &expiring5d},
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "later.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{NotAfter: &expiring60d},
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "dead.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{NotAfter: &expired},
+			},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{ExpiresWithin: "30d"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 report expiring within 30d, got %d", len(filtered))
+	}
+	if filtered[0].Spec.Host != "soon.test" {
+		t.Errorf("expected soon.test, got %s", filtered[0].Spec.Host)
+	}
+}
+
+func TestFilterReports_CombinedWithPQC(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "a.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService, SourceNamespace: "prod"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     securityv1alpha1.PQCReadinessLegacyTLS,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "b.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService, SourceNamespace: "prod"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     securityv1alpha1.PQCReadinessPQCReady,
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "c.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService, SourceNamespace: "dev"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				PQCReadiness:     securityv1alpha1.PQCReadinessLegacyTLS,
+			},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{Namespace: "prod", PQCStatus: "LegacyTLS"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(filtered))
+	}
+	if filtered[0].Spec.Host != "a.test" {
+		t.Errorf("expected a.test, got %s", filtered[0].Spec.Host)
+	}
+}
+
+func TestParseExpiresWithin(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+		err   bool
+	}{
+		{"7d", 7 * 24 * time.Hour, false},
+		{"30d", 30 * 24 * time.Hour, false},
+		{"90d", 90 * 24 * time.Hour, false},
+		{"24h", 24 * time.Hour, false},
+		{"", 0, true},
+		{"abc", 0, true},
+	}
+
+	for _, tt := range tests {
+		got, err := ParseExpiresWithin(tt.input)
+		if tt.err && err == nil {
+			t.Errorf("ParseExpiresWithin(%q): expected error", tt.input)
+		}
+		if !tt.err && err != nil {
+			t.Errorf("ParseExpiresWithin(%q): unexpected error: %v", tt.input, err)
+		}
+		if !tt.err && got != tt.want {
+			t.Errorf("ParseExpiresWithin(%q) = %v, want %v", tt.input, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `--pqc-status` flag to filter by PQC readiness (PQCReady, TLS13Capable, LegacyTLS, NoPQC)
- Add `--expires-within` flag to show certs expiring within a duration (e.g. 30d, 7d, 90d)
- Add `--expired` flag to show only expired certificates
- All filters are case-insensitive and combine with AND logic
- Duration parsing supports day notation (30d) and Go durations (24h)

## Test plan
- 7 new filter tests covering PQC status, case insensitivity, expired certs, expires-within, combined filters
- Duration parser tests for valid and invalid inputs
- CLI flag existence tests updated

Fixes #131