### PR TITLE
Add --sort-by flag to kubectl-tlsreport plugin

### DIFF
--- a/cmd/kubectl-tlsreport/main.go
+++ b/cmd/kubectl-tlsreport/main.go
@@ -39,7 +39,10 @@ func init() {
 	utilruntime.Must(securityv1alpha1.AddToScheme(scheme))
 }
 
-var filterOpts export.FilterOptions
+var (
+	filterOpts export.FilterOptions
+	sortBy     string
+)
 
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
@@ -66,6 +69,7 @@ Supported formats: csv (default), json, junit`,
 	rootCmd.PersistentFlags().StringVar(&filterOpts.PQCStatus, "pqc-status", "", "Filter by PQC readiness (PQCReady, TLS13Capable, LegacyTLS, NoPQC)")
 	rootCmd.PersistentFlags().StringVar(&filterOpts.ExpiresWithin, "expires-within", "", "Show certs expiring within duration (e.g. 30d, 7d, 90d)")
 	rootCmd.PersistentFlags().BoolVar(&filterOpts.Expired, "expired", false, "Show only expired certificates")
+	rootCmd.PersistentFlags().StringVar(&sortBy, "sort-by", "", "Sort results by field (host, port, compliance, expiry, grade, pqc)")
 
 	rootCmd.AddCommand(newSummaryCmd())
 
@@ -102,6 +106,8 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	export.SortReports(reports, sortBy)
+
 	switch format {
 	case "csv":
 		return export.WriteCSV(os.Stdout, reports)
@@ -124,6 +130,8 @@ func runSummary(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+
+	export.SortReports(reports, sortBy)
 
 	return export.WriteSummary(os.Stdout, reports)
 }

--- a/cmd/kubectl-tlsreport/main_test.go
+++ b/cmd/kubectl-tlsreport/main_test.go
@@ -59,6 +59,7 @@ func TestNewRootCmd_Flags(t *testing.T) {
 		{"pqc-status", ""},
 		{"expires-within", ""},
 		{"expired", ""},
+		{"sort-by", ""},
 	}
 
 	for _, tt := range tests {

--- a/docs/exporting-reports.md
+++ b/docs/exporting-reports.md
@@ -65,6 +65,30 @@ All filters use AND logic. PQC status values: `PQCReady`, `TLS13Capable`, `Legac
 The `--expires-within` flag accepts day-based durations (e.g. `7d`, `30d`, `90d`) or Go durations (e.g. `24h`).
 The `--expired` flag excludes endpoints without certificates.
 
+## Sorting
+
+Sort results with `--sort-by`:
+
+```bash
+# Sort by hostname
+kubectl tlsreport csv --sort-by host
+
+# Sort by certificate expiry (soonest first)
+kubectl tlsreport csv --sort-by expiry
+
+# Sort by cipher grade
+kubectl tlsreport csv --sort-by grade
+
+# Sort by PQC readiness
+kubectl tlsreport csv --sort-by pqc
+
+# Combine with filters: non-compliant endpoints sorted by expiry
+kubectl tlsreport csv --status NonCompliant --sort-by expiry
+```
+
+Supported sort keys: `host`, `port`, `compliance`, `expiry`, `grade`, `pqc`.
+Endpoints without certificates sort to the end when sorting by `expiry`.
+
 ## Summary View
 
 Get an at-a-glance compliance summary:

--- a/pkg/export/sort.go
+++ b/pkg/export/sort.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+var compliancePriority = map[securityv1alpha1.ComplianceStatus]int{
+	securityv1alpha1.ComplianceStatusCompliant:         0,
+	securityv1alpha1.ComplianceStatusWarning:           1,
+	securityv1alpha1.ComplianceStatusNonCompliant:      2,
+	securityv1alpha1.ComplianceStatusNoTLS:             3,
+	securityv1alpha1.ComplianceStatusMutualTLSRequired: 4,
+	securityv1alpha1.ComplianceStatusTimeout:           5,
+	securityv1alpha1.ComplianceStatusClosed:            6,
+	securityv1alpha1.ComplianceStatusFiltered:          7,
+	securityv1alpha1.ComplianceStatusUnreachable:       8,
+	securityv1alpha1.ComplianceStatusPending:           9,
+	securityv1alpha1.ComplianceStatusUnknown:           10,
+}
+
+// SortReports sorts reports in place by the given key.
+// Supported keys: host, port, compliance, expiry, grade, pqc.
+// Unknown or empty keys are a no-op.
+func SortReports(reports []securityv1alpha1.TLSComplianceReport, sortBy string) {
+	switch strings.ToLower(sortBy) {
+	case "host":
+		sort.SliceStable(reports, func(i, j int) bool {
+			return reports[i].Spec.Host < reports[j].Spec.Host
+		})
+	case "port":
+		sort.SliceStable(reports, func(i, j int) bool {
+			return reports[i].Spec.Port < reports[j].Spec.Port
+		})
+	case "compliance":
+		sort.SliceStable(reports, func(i, j int) bool {
+			return compliancePriority[reports[i].Status.ComplianceStatus] <
+				compliancePriority[reports[j].Status.ComplianceStatus]
+		})
+	case "expiry":
+		sort.SliceStable(reports, func(i, j int) bool {
+			return certExpiry(&reports[i]).Before(certExpiry(&reports[j]))
+		})
+	case "grade":
+		sort.SliceStable(reports, func(i, j int) bool {
+			return emptyLast(reports[i].Status.OverallCipherGrade, reports[j].Status.OverallCipherGrade)
+		})
+	case "pqc":
+		sort.SliceStable(reports, func(i, j int) bool {
+			return emptyLast(string(reports[i].Status.PQCReadiness), string(reports[j].Status.PQCReadiness))
+		})
+	}
+}
+
+var distantFuture = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func certExpiry(r *securityv1alpha1.TLSComplianceReport) time.Time {
+	if r.Status.CertificateInfo != nil && r.Status.CertificateInfo.NotAfter != nil {
+		return r.Status.CertificateInfo.NotAfter.Time
+	}
+	return distantFuture
+}
+
+func emptyLast(a, b string) bool {
+	if a == "" && b == "" {
+		return false
+	}
+	if a == "" {
+		return false
+	}
+	if b == "" {
+		return true
+	}
+	return a < b
+}

--- a/pkg/export/sort_test.go
+++ b/pkg/export/sort_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+func sortTestReports() []securityv1alpha1.TLSComplianceReport {
+	exp1 := metav1.NewTime(time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+	exp2 := metav1.NewTime(time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC))
+
+	return []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "charlie.test", Port: 8443},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus:   securityv1alpha1.ComplianceStatusNonCompliant,
+				OverallCipherGrade: "C",
+				PQCReadiness:       securityv1alpha1.PQCReadinessLegacyTLS,
+				CertificateInfo:    &securityv1alpha1.CertificateInfo{NotAfter: &exp2},
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "alpha.test", Port: 443},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus:   securityv1alpha1.ComplianceStatusCompliant,
+				OverallCipherGrade: "A",
+				PQCReadiness:       securityv1alpha1.PQCReadinessPQCReady,
+				CertificateInfo:    &securityv1alpha1.CertificateInfo{NotAfter: &exp1},
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "bravo.test", Port: 443},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus:   securityv1alpha1.ComplianceStatusCompliant,
+				OverallCipherGrade: "B",
+				PQCReadiness:       securityv1alpha1.PQCReadinessTLS13Capable,
+			},
+		},
+	}
+}
+
+func TestSortReports_ByHost(t *testing.T) {
+	reports := sortTestReports()
+	SortReports(reports, "host")
+
+	if reports[0].Spec.Host != "alpha.test" {
+		t.Errorf("expected alpha.test first, got %s", reports[0].Spec.Host)
+	}
+	if reports[1].Spec.Host != "bravo.test" {
+		t.Errorf("expected bravo.test second, got %s", reports[1].Spec.Host)
+	}
+	if reports[2].Spec.Host != "charlie.test" {
+		t.Errorf("expected charlie.test third, got %s", reports[2].Spec.Host)
+	}
+}
+
+func TestSortReports_ByPort(t *testing.T) {
+	reports := sortTestReports()
+	SortReports(reports, "port")
+
+	if reports[0].Spec.Port != 443 {
+		t.Errorf("expected port 443 first, got %d", reports[0].Spec.Port)
+	}
+	if reports[2].Spec.Port != 8443 {
+		t.Errorf("expected port 8443 last, got %d", reports[2].Spec.Port)
+	}
+}
+
+func TestSortReports_ByCompliance(t *testing.T) {
+	reports := sortTestReports()
+	SortReports(reports, "compliance")
+
+	if reports[0].Status.ComplianceStatus != securityv1alpha1.ComplianceStatusCompliant {
+		t.Errorf("expected Compliant first, got %s", reports[0].Status.ComplianceStatus)
+	}
+	if reports[2].Status.ComplianceStatus != securityv1alpha1.ComplianceStatusNonCompliant {
+		t.Errorf("expected NonCompliant last, got %s", reports[2].Status.ComplianceStatus)
+	}
+}
+
+func TestSortReports_ByExpiry(t *testing.T) {
+	reports := sortTestReports()
+	SortReports(reports, "expiry")
+
+	if reports[0].Spec.Host != "alpha.test" {
+		t.Errorf("expected alpha.test (earliest expiry) first, got %s", reports[0].Spec.Host)
+	}
+	if reports[1].Spec.Host != "charlie.test" {
+		t.Errorf("expected charlie.test second, got %s", reports[1].Spec.Host)
+	}
+	if reports[2].Spec.Host != "bravo.test" {
+		t.Errorf("expected bravo.test (no cert, sorts last) third, got %s", reports[2].Spec.Host)
+	}
+}
+
+func TestSortReports_ByGrade(t *testing.T) {
+	reports := sortTestReports()
+	SortReports(reports, "grade")
+
+	if reports[0].Status.OverallCipherGrade != "A" {
+		t.Errorf("expected grade A first, got %s", reports[0].Status.OverallCipherGrade)
+	}
+	if reports[2].Status.OverallCipherGrade != "C" {
+		t.Errorf("expected grade C last, got %s", reports[2].Status.OverallCipherGrade)
+	}
+}
+
+func TestSortReports_ByPQC(t *testing.T) {
+	reports := sortTestReports()
+	SortReports(reports, "pqc")
+
+	if reports[0].Status.PQCReadiness != securityv1alpha1.PQCReadinessLegacyTLS {
+		t.Errorf("expected LegacyTLS first, got %s", reports[0].Status.PQCReadiness)
+	}
+	if reports[2].Status.PQCReadiness != securityv1alpha1.PQCReadinessTLS13Capable {
+		t.Errorf("expected TLS13Capable last, got %s", reports[2].Status.PQCReadiness)
+	}
+}
+
+func TestSortReports_EmptyKey(t *testing.T) {
+	reports := sortTestReports()
+	original := reports[0].Spec.Host
+
+	SortReports(reports, "")
+
+	if reports[0].Spec.Host != original {
+		t.Error("empty sort key should be a no-op")
+	}
+}
+
+func TestSortReports_UnknownKey(t *testing.T) {
+	reports := sortTestReports()
+	original := reports[0].Spec.Host
+
+	SortReports(reports, "nonexistent")
+
+	if reports[0].Spec.Host != original {
+		t.Error("unknown sort key should be a no-op")
+	}
+}
+
+func TestSortReports_CaseInsensitiveKey(t *testing.T) {
+	reports := sortTestReports()
+	SortReports(reports, "HOST")
+
+	if reports[0].Spec.Host != "alpha.test" {
+		t.Errorf("expected alpha.test first with uppercase HOST key, got %s", reports[0].Spec.Host)
+	}
+}
+
+func TestSortReports_EmptyGradeSortsLast(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "no-grade.test"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{OverallCipherGrade: ""},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "grade-b.test"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{OverallCipherGrade: "B"},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "grade-a.test"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{OverallCipherGrade: "A"},
+		},
+	}
+
+	SortReports(reports, "grade")
+
+	if reports[0].Status.OverallCipherGrade != "A" {
+		t.Errorf("expected grade A first, got %q", reports[0].Status.OverallCipherGrade)
+	}
+	if reports[1].Status.OverallCipherGrade != "B" {
+		t.Errorf("expected grade B second, got %q", reports[1].Status.OverallCipherGrade)
+	}
+	if reports[2].Status.OverallCipherGrade != "" {
+		t.Errorf("expected empty grade last, got %q", reports[2].Status.OverallCipherGrade)
+	}
+}
+
+func TestSortReports_CompliancePriority(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "unreachable.test"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusUnreachable},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "compliant.test"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "noncompliant.test"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusNonCompliant},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "notls.test"},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusNoTLS},
+		},
+	}
+
+	SortReports(reports, "compliance")
+
+	expected := []securityv1alpha1.ComplianceStatus{
+		securityv1alpha1.ComplianceStatusCompliant,
+		securityv1alpha1.ComplianceStatusNonCompliant,
+		securityv1alpha1.ComplianceStatusNoTLS,
+		securityv1alpha1.ComplianceStatusUnreachable,
+	}
+
+	for i, want := range expected {
+		if reports[i].Status.ComplianceStatus != want {
+			t.Errorf("position %d: expected %s, got %s", i, want, reports[i].Status.ComplianceStatus)
+		}
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -346,4 +346,71 @@ spec:
 			}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 		})
 	})
+
+	Context("kubectl-tlsreport plugin", func() {
+		var pluginBinary string
+
+		BeforeAll(func() {
+			By("building the kubectl-tlsreport plugin")
+			cmd := exec.Command("go", "build", "-o", "/tmp/kubectl-tlsreport", "./cmd/kubectl-tlsreport/")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to build kubectl-tlsreport plugin")
+			pluginBinary = "/tmp/kubectl-tlsreport"
+
+			By("creating test services for sort validation")
+			for _, name := range []string{"zulu-svc", "alpha-svc", "mike-svc"} {
+				cmd := exec.Command("kubectl", "create", "service", "clusterip", name,
+					"--tcp=443:443", "-n", "default")
+				_, err := utils.Run(cmd)
+				Expect(err).NotTo(HaveOccurred(), "Failed to create service "+name)
+			}
+
+			By("waiting for TLSComplianceReports to be created for all test services")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "tlsreport", "-o",
+					"jsonpath={range .items[*]}{.spec.host}{\"\\n\"}{end}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("alpha-svc"))
+				g.Expect(output).To(ContainSubstring("mike-svc"))
+				g.Expect(output).To(ContainSubstring("zulu-svc"))
+			}).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			for _, name := range []string{"zulu-svc", "alpha-svc", "mike-svc"} {
+				cmd := exec.Command("kubectl", "delete", "service", name, "-n", "default", "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			}
+		})
+
+		It("should sort reports by host", func() {
+			cmd := exec.Command(pluginBinary, "csv", "--sort-by", "host")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to run kubectl-tlsreport csv --sort-by host")
+
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			Expect(len(lines)).To(BeNumerically(">=", 4), "expected header + at least 3 data rows")
+
+			var hosts []string
+			for _, line := range lines[1:] {
+				fields := strings.Split(line, ",")
+				if len(fields) > 0 {
+					hosts = append(hosts, fields[0])
+				}
+			}
+
+			for i := 1; i < len(hosts); i++ {
+				Expect(hosts[i] >= hosts[i-1]).To(BeTrue(),
+					fmt.Sprintf("hosts not sorted: %q should come after %q", hosts[i], hosts[i-1]))
+			}
+		})
+
+		It("should produce valid JSON with --sort-by", func() {
+			cmd := exec.Command(pluginBinary, "json", "--sort-by", "host")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to run kubectl-tlsreport json --sort-by host")
+			Expect(output).To(HavePrefix("["), "expected JSON array output")
+		})
+	})
 })


### PR DESCRIPTION
## Summary
- Add `--sort-by` flag supporting: `host`, `port`, `compliance`, `expiry`, `grade`, `pqc`
- Uses `sort.SliceStable` for deterministic ordering
- Endpoints without certificates sort to the end when sorting by `expiry`
- Sort keys are case-insensitive; unknown or empty keys are a no-op
- Applied after filtering, before output

## Test plan
- 9 tests covering all sort keys, empty/unknown keys, and case insensitivity
- CLI flag existence test updated
- Manual testing pending (Quay outage)

Fixes #129