### PR TITLE
Add Markdown table export to kubectl-tlsreport plugin

### DIFF
--- a/cmd/kubectl-tlsreport/main.go
+++ b/cmd/kubectl-tlsreport/main.go
@@ -52,11 +52,11 @@ func main() {
 
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "kubectl-tlsreport [csv|json|junit]",
+		Use:   "kubectl-tlsreport [csv|json|junit|markdown|md]",
 		Short: "Export TLS compliance reports from the cluster",
 		Long: `Export TLS compliance reports from the cluster in various formats.
 
-Supported formats: csv (default), json, junit`,
+Supported formats: csv (default), json, junit, markdown (or md)`,
 		Args:          cobra.MaximumNArgs(1),
 		RunE:          runExport,
 		SilenceUsage:  true,
@@ -91,9 +91,9 @@ func runExport(cmd *cobra.Command, args []string) error {
 	}
 
 	switch format {
-	case "csv", "json", "junit":
+	case "csv", "json", "junit", "markdown", "md":
 	default:
-		return fmt.Errorf("unknown format: %s (supported: csv, json, junit)", format)
+		return fmt.Errorf("unknown format: %s (supported: csv, json, junit, markdown, md)", format)
 	}
 
 	reports, err := fetchReports()
@@ -115,6 +115,8 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return export.WriteJSON(os.Stdout, reports)
 	case "junit":
 		return export.WriteJUnit(os.Stdout, reports)
+	case "markdown", "md":
+		return export.WriteMarkdown(os.Stdout, reports)
 	}
 
 	return nil

--- a/cmd/kubectl-tlsreport/main_test.go
+++ b/cmd/kubectl-tlsreport/main_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"strings"
 	"testing"
 
 	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
@@ -25,7 +26,7 @@ import (
 func TestNewRootCmd_Structure(t *testing.T) {
 	cmd := newRootCmd()
 
-	if cmd.Use != "kubectl-tlsreport [csv|json|junit]" {
+	if cmd.Use != "kubectl-tlsreport [csv|json|junit|markdown|md]" {
 		t.Errorf("unexpected Use: %s", cmd.Use)
 	}
 
@@ -82,13 +83,13 @@ func TestRunExport_InvalidFormat(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid format")
 	}
-	if err.Error() != "unknown format: xml (supported: csv, json, junit)" {
+	if err.Error() != "unknown format: xml (supported: csv, json, junit, markdown, md)" {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }
 
 func TestRunExport_ValidFormats(t *testing.T) {
-	for _, format := range []string{"csv", "json", "junit"} {
+	for _, format := range []string{"csv", "json", "junit", "markdown", "md"} {
 		cmd := newRootCmd()
 		cmd.SetArgs([]string{format})
 
@@ -96,8 +97,8 @@ func TestRunExport_ValidFormats(t *testing.T) {
 		if err == nil {
 			t.Skipf("format %q: skipping (no kubeconfig available)", format)
 		}
-		if err.Error() == "unknown format: "+format+" (supported: csv, json, junit)" {
-			t.Errorf("format %q should be valid but was rejected", format)
+		if strings.HasPrefix(err.Error(), "unknown format:") {
+			t.Errorf("format %q should be valid but was rejected: %v", format, err)
 		}
 	}
 }

--- a/docs/exporting-reports.md
+++ b/docs/exporting-reports.md
@@ -34,6 +34,21 @@ kubectl tlsreport json
 kubectl tlsreport junit
 ```
 
+**Markdown** (for GitHub issues, wikis, and documentation):
+
+```bash
+kubectl tlsreport markdown
+kubectl tlsreport md  # shorthand
+```
+
+Produces a Markdown table matching `kubectl get tlsreport` columns:
+
+```
+| Host | Port | Source | Compliance | Grade | FS | TLS1.3 | TLS1.2 | TLS1.0 | PQC | CertExpiry | Age |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| my-service.default | 443 | Service | Compliant | A | true | true | true | false | PQCReady | 364 | 5m |
+```
+
 ## Filtering
 
 Filter by namespace, compliance status, source kind, PQC readiness, or certificate expiry:

--- a/pkg/export/markdown.go
+++ b/pkg/export/markdown.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+var markdownHeader = []string{
+	"Host", "Port", "Source", "Compliance", "Grade", "FS",
+	"TLS1.3", "TLS1.2", "TLS1.0", "PQC", "CertExpiry", "Age",
+}
+
+// WriteMarkdown writes TLSComplianceReport items as a Markdown table to the given writer.
+// Columns match kubectl get tlsreport output for familiarity.
+func WriteMarkdown(w io.Writer, reports []securityv1alpha1.TLSComplianceReport) error {
+	if _, err := fmt.Fprintf(w, "| %s |\n", strings.Join(markdownHeader, " | ")); err != nil {
+		return err
+	}
+
+	separators := make([]string, len(markdownHeader))
+	for i := range separators {
+		separators[i] = "---"
+	}
+	if _, err := fmt.Fprintf(w, "| %s |\n", strings.Join(separators, " | ")); err != nil {
+		return err
+	}
+
+	now := time.Now()
+	for i := range reports {
+		row := reportToMarkdownRow(&reports[i], now)
+		if _, err := fmt.Fprintf(w, "| %s |\n", strings.Join(row, " | ")); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func reportToMarkdownRow(r *securityv1alpha1.TLSComplianceReport, now time.Time) []string {
+	var certExpiry, age string
+
+	if r.Status.CertificateInfo != nil {
+		certExpiry = strconv.Itoa(r.Status.CertificateInfo.DaysUntilExpiry)
+	}
+
+	if !r.CreationTimestamp.IsZero() {
+		age = formatAge(now.Sub(r.CreationTimestamp.Time))
+	}
+
+	return []string{
+		escPipe(r.Spec.Host),
+		strconv.Itoa(int(r.Spec.Port)),
+		string(r.Spec.SourceKind),
+		string(r.Status.ComplianceStatus),
+		r.Status.OverallCipherGrade,
+		strconv.FormatBool(r.Status.ForwardSecrecy),
+		strconv.FormatBool(r.Status.TLSVersions.TLS13),
+		strconv.FormatBool(r.Status.TLSVersions.TLS12),
+		strconv.FormatBool(r.Status.TLSVersions.TLS10),
+		string(r.Status.PQCReadiness),
+		certExpiry,
+		age,
+	}
+}
+
+func escPipe(s string) string {
+	return strings.ReplaceAll(s, "|", `\|`)
+}
+
+func formatAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/pkg/export/markdown_test.go
+++ b/pkg/export/markdown_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package export
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
+)
+
+func TestWriteMarkdown_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteMarkdown(&buf, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (header + separator), got %d", len(lines))
+	}
+	if !strings.HasPrefix(lines[0], "| Host") {
+		t.Errorf("expected header to start with '| Host', got: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "---") {
+		t.Errorf("expected separator row with ---, got: %s", lines[1])
+	}
+}
+
+func TestWriteMarkdown_SingleReport(t *testing.T) {
+	now := time.Now()
+	created := metav1.NewTime(now.Add(-5 * time.Minute))
+
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: created},
+			Spec: securityv1alpha1.TLSComplianceReportSpec{
+				Host:            "my-service.default",
+				Port:            443,
+				SourceKind:      securityv1alpha1.SourceKindService,
+				SourceNamespace: "default",
+				SourceName:      "my-service",
+			},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus:   securityv1alpha1.ComplianceStatusCompliant,
+				OverallCipherGrade: "A",
+				ForwardSecrecy:     true,
+				TLSVersions: securityv1alpha1.TLSVersionSupport{
+					TLS13: true,
+					TLS12: true,
+				},
+				PQCReadiness: securityv1alpha1.PQCReadinessPQCReady,
+				CertificateInfo: &securityv1alpha1.CertificateInfo{
+					DaysUntilExpiry: 364,
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := WriteMarkdown(&buf, reports)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (header + separator + 1 row), got %d", len(lines))
+	}
+
+	row := lines[2]
+	for _, field := range []string{"my-service.default", "443", "Service", "Compliant", "A", "PQCReady", "364", "5m"} {
+		if !strings.Contains(row, field) {
+			t.Errorf("expected row to contain %q, got: %s", field, row)
+		}
+	}
+}
+
+func TestWriteMarkdown_MultipleReports(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "svc1.ns1", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "svc2.ns2", Port: 8443, SourceKind: securityv1alpha1.SourceKindRoute},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusNonCompliant},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines (header + separator + 2 rows), got %d", len(lines))
+	}
+}
+
+func TestWriteMarkdown_NoCertificate(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "no-cert.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusNoTLS},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	row := lines[2]
+	if !strings.Contains(row, "NoTLS") {
+		t.Error("expected row to contain NoTLS")
+	}
+}
+
+func TestWriteMarkdown_TableStructure(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "test.example", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "|") || !strings.HasSuffix(line, "|") {
+			t.Errorf("line %d should start and end with pipe: %s", i, line)
+		}
+	}
+
+	headerPipes := strings.Count(lines[0], "|")
+	for i, line := range lines[1:] {
+		if strings.Count(line, "|") != headerPipes {
+			t.Errorf("line %d has %d pipes, expected %d (same as header)", i+1, strings.Count(line, "|"), headerPipes)
+		}
+	}
+}
+
+func TestWriteMarkdown_AllComplianceStatuses(t *testing.T) {
+	statuses := []securityv1alpha1.ComplianceStatus{
+		securityv1alpha1.ComplianceStatusCompliant,
+		securityv1alpha1.ComplianceStatusNonCompliant,
+		securityv1alpha1.ComplianceStatusWarning,
+		securityv1alpha1.ComplianceStatusUnreachable,
+		securityv1alpha1.ComplianceStatusTimeout,
+		securityv1alpha1.ComplianceStatusClosed,
+		securityv1alpha1.ComplianceStatusFiltered,
+		securityv1alpha1.ComplianceStatusNoTLS,
+		securityv1alpha1.ComplianceStatusMutualTLSRequired,
+		securityv1alpha1.ComplianceStatusPending,
+		securityv1alpha1.ComplianceStatusUnknown,
+	}
+
+	var reports []securityv1alpha1.TLSComplianceReport
+	for i, s := range statuses {
+		reports = append(reports, securityv1alpha1.TLSComplianceReport{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: fmt.Sprintf("svc%d.test", i), Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: s},
+		})
+	}
+
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	for _, s := range statuses {
+		if !strings.Contains(output, string(s)) {
+			t.Errorf("expected output to contain status %q", s)
+		}
+	}
+}
+
+func TestWriteMarkdown_PipeEscaping(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "host|with|pipes.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteMarkdown(&buf, reports); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	row := lines[2]
+	if !strings.Contains(row, `host\|with\|pipes.test`) {
+		t.Errorf("expected pipes in host to be escaped, got: %s", row)
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "30s"},
+		{5 * time.Minute, "5m"},
+		{2 * time.Hour, "2h"},
+		{3 * 24 * time.Hour, "3d"},
+		{90 * 24 * time.Hour, "90d"},
+	}
+
+	for _, tt := range tests {
+		got := formatAge(tt.d)
+		if got != tt.want {
+			t.Errorf("formatAge(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -412,5 +412,21 @@ spec:
 			Expect(err).NotTo(HaveOccurred(), "Failed to run kubectl-tlsreport json --sort-by host")
 			Expect(output).To(HavePrefix("["), "expected JSON array output")
 		})
+
+		It("should produce a valid Markdown table", func() {
+			cmd := exec.Command(pluginBinary, "md")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to run kubectl-tlsreport md")
+
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			Expect(len(lines)).To(BeNumerically(">=", 3), "expected header + separator + at least 1 data row")
+			Expect(lines[0]).To(HavePrefix("| Host"))
+			Expect(lines[1]).To(ContainSubstring("---"))
+
+			for _, line := range lines {
+				Expect(line).To(HavePrefix("|"), "each line should start with pipe")
+				Expect(line).To(HaveSuffix("|"), "each line should end with pipe")
+			}
+		})
 	})
 })


### PR DESCRIPTION
## Summary
- Add `markdown` (or `md`) output format producing a Markdown table
- Columns match `kubectl get tlsreport`: Host, Port, Source, Compliance, Grade, FS, TLS1.3, TLS1.2, TLS1.0, PQC, CertExpiry, Age
- Pipe characters in field values are escaped
- Human-readable age formatting (30s, 5m, 2h, 3d)

## Example output
```
| Host | Port | Source | Compliance | Grade | FS | TLS1.3 | TLS1.2 | TLS1.0 | PQC | CertExpiry | Age |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| my-service.default | 443 | Service | Compliant | A | true | true | true | false | PQCReady | 364 | 5m |
```

## Test plan
- 8 unit tests: empty, single, multiple, no cert, table structure, all statuses, pipe escaping, age formatting
- E2E test validates markdown output structure on Kind cluster
- Manual testing on cnfdt16 pending (Quay outage)

Fixes #140