### PR TITLE
Add extra TLS ports, expanded defaults, and JSON logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -41,6 +42,7 @@ import (
 
 	securityv1alpha1 "github.com/sebrandon1/tls-compliance-operator/api/v1alpha1"
 	"github.com/sebrandon1/tls-compliance-operator/internal/controller"
+	"github.com/sebrandon1/tls-compliance-operator/pkg/endpoint"
 	"github.com/sebrandon1/tls-compliance-operator/pkg/tlscheck"
 	"github.com/sebrandon1/tls-compliance-operator/pkg/tlsprofile"
 	// +kubebuilder:scaffold:imports
@@ -82,6 +84,8 @@ func main() {
 	var workers int
 	var maxRetries int
 	var retryBackoff time.Duration
+	var extraTLSPortsStr string
+	var logFormat string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -126,6 +130,10 @@ func main() {
 		"Maximum number of retries for transient TLS check failures (0-10)")
 	flag.DurationVar(&retryBackoff, "retry-backoff", 30*time.Second,
 		"Base backoff duration between retries (exponential: base * 2^attempt)")
+	flag.StringVar(&extraTLSPortsStr, "extra-tls-ports", "",
+		"Comma-separated list of additional port numbers to treat as TLS endpoints (e.g., 9443,6380,5671)")
+	flag.StringVar(&logFormat, "log-format", "text",
+		"Log output format: text or json")
 
 	opts := zap.Options{
 		Development: true,
@@ -133,12 +141,34 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	// Apply environment variable overrides before logger creation so that
+	// TLS_COMPLIANCE_LOG_FORMAT=json takes effect on the logger.
+	envOverrides := resolveEnvConfig(flag.CommandLine, os.LookupEnv)
+
+	// Validate log format (after env overrides may have changed it)
+	if logFormat != "text" && logFormat != "json" {
+		fmt.Fprintf(os.Stderr, "invalid --log-format value, must be text or json, got %q\n", logFormat)
+		os.Exit(1)
+	}
+
+	if logFormat == "json" {
+		opts.Development = false
+	}
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	// Apply environment variable overrides for flags not explicitly set on the command line
-	envOverrides := resolveEnvConfig(flag.CommandLine, os.LookupEnv)
 	for _, msg := range envOverrides {
 		setupLog.Info(msg)
+	}
+
+	// Parse and apply extra TLS ports
+	if extraTLSPortsStr != "" {
+		ports, err := parsePortList(extraTLSPortsStr)
+		if err != nil {
+			setupLog.Error(err, "invalid --extra-tls-ports value")
+			os.Exit(1)
+		}
+		endpoint.SetExtraTLSPorts(ports)
+		setupLog.Info("extra TLS ports configured", "ports", extraTLSPortsStr)
 	}
 
 	// Validate workers flag
@@ -336,6 +366,8 @@ var envFlagMapping = []struct {
 	{"TLS_COMPLIANCE_PROFILE_REFRESH_INTERVAL", "profile-refresh-interval"},
 	{"TLS_COMPLIANCE_MAX_RETRIES", "max-retries"},
 	{"TLS_COMPLIANCE_RETRY_BACKOFF", "retry-backoff"},
+	{"TLS_COMPLIANCE_EXTRA_TLS_PORTS", "extra-tls-ports"},
+	{"TLS_COMPLIANCE_LOG_FORMAT", "log-format"},
 }
 
 // resolveEnvConfig applies environment variable overrides to flags that were not
@@ -403,6 +435,13 @@ func validateEnvValue(flagName, value string) error {
 		return validateIntRange(value, 1, 50)
 	case "max-retries":
 		return validateIntRange(value, 0, 10)
+	case "extra-tls-ports":
+		_, err := parsePortList(value)
+		return err
+	case "log-format":
+		if value != "text" && value != "json" {
+			return fmt.Errorf("must be text or json, got %q", value)
+		}
 	}
 	return nil
 }
@@ -416,4 +455,23 @@ func validateIntRange(value string, min, max int) error {
 		return fmt.Errorf("must be between %d and %d, got %d", min, max, v)
 	}
 	return nil
+}
+
+func parsePortList(value string) (map[int32]bool, error) {
+	ports := map[int32]bool{}
+	for _, s := range strings.Split(value, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		p, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid port %q: %w", s, err)
+		}
+		if p < 1 || p > 65535 {
+			return nil, fmt.Errorf("port %d out of range (1-65535)", p)
+		}
+		ports[int32(p)] = true
+	}
+	return ports, nil
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -233,6 +233,13 @@ func TestValidateEnvValue(t *testing.T) {
 		{"workers too high", "workers", "51", true},
 		{"invalid workers", "workers", "abc", true},
 		{"unknown flag passes", "exclude-namespaces", "anything", false},
+		{"valid extra-tls-ports", "extra-tls-ports", "9443,6380,5671", false},
+		{"invalid extra-tls-ports non-number", "extra-tls-ports", "abc", true},
+		{"invalid extra-tls-ports out of range", "extra-tls-ports", "70000", true},
+		{"invalid extra-tls-ports zero", "extra-tls-ports", "0", true},
+		{"valid log-format text", "log-format", "text", false},
+		{"valid log-format json", "log-format", "json", false},
+		{"invalid log-format", "log-format", "xml", true},
 	}
 
 	for _, tc := range tests {
@@ -242,5 +249,79 @@ func TestValidateEnvValue(t *testing.T) {
 				t.Errorf("validateEnvValue(%s, %s) error = %v, wantErr = %v", tc.flag, tc.value, err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestParsePortList(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{"single port", "9443", 1, false},
+		{"multiple ports", "9443,6380,5671", 3, false},
+		{"spaces trimmed", " 9443 , 6380 ", 2, false},
+		{"empty string", "", 0, false},
+		{"trailing comma", "9443,", 1, false},
+		{"non-number", "abc", 0, true},
+		{"port zero", "0", 0, true},
+		{"port too high", "65536", 0, true},
+		{"negative port", "-1", 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ports, err := parsePortList(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parsePortList(%q) error = %v, wantErr = %v", tc.input, err, tc.wantErr)
+				return
+			}
+			if !tc.wantErr && len(ports) != tc.want {
+				t.Errorf("parsePortList(%q) returned %d ports, want %d", tc.input, len(ports), tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveEnvConfig_ExtraTLSPorts(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("extra-tls-ports", "", "")
+	_ = fs.Parse([]string{})
+
+	env := map[string]string{
+		"TLS_COMPLIANCE_EXTRA_TLS_PORTS": "9443,6380",
+	}
+	lookup := func(key string) (string, bool) {
+		v, ok := env[key]
+		return v, ok
+	}
+
+	_ = resolveEnvConfig(fs, lookup)
+
+	val := fs.Lookup("extra-tls-ports").Value.String()
+	if val != "9443,6380" {
+		t.Errorf("expected extra-tls-ports=9443,6380, got %s", val)
+	}
+}
+
+func TestResolveEnvConfig_LogFormat(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("log-format", "text", "")
+	_ = fs.Parse([]string{})
+
+	env := map[string]string{
+		"TLS_COMPLIANCE_LOG_FORMAT": "json",
+	}
+	lookup := func(key string) (string, bool) {
+		v, ok := env[key]
+		return v, ok
+	}
+
+	_ = resolveEnvConfig(fs, lookup)
+
+	val := fs.Lookup("log-format").Value.String()
+	if val != "json" {
+		t.Errorf("expected log-format=json, got %s", val)
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ If a flag is set on the command line, its environment variable is ignored.
 | `--cleanup-interval` | `TLS_COMPLIANCE_CLEANUP_INTERVAL` | duration | `5m` | How often the operator removes TLSComplianceReport CRs whose source resource (Service, Ingress, Route) has been deleted. |
 | `--tls-check-timeout` | `TLS_COMPLIANCE_CHECK_TIMEOUT` | duration | `5s` | Timeout for each individual TLS connection attempt. The operator probes TLS 1.0, 1.1, 1.2, 1.3, and SSLv3 sequentially, so worst-case time per endpoint is roughly 5x this value. Increase on high-latency networks. |
 | `--workers` | `TLS_COMPLIANCE_WORKERS` | int | `5` | Number of concurrent goroutines used during periodic scans. Range: 1-50. Higher values scan faster but use more CPU and network. This also controls `MaxConcurrentReconciles` for the controller work queue. |
+| `--extra-tls-ports` | `TLS_COMPLIANCE_EXTRA_TLS_PORTS` | string | `""` | Comma-separated list of additional port numbers to treat as TLS endpoints (e.g., `12345,54321`). These are checked in addition to the built-in defaults (443, 8443, 9443, 2379, 5671, 6380, 9200) and any port named `https` or `https-*`. |
 
 ## Rate Limiting
 
@@ -52,6 +53,12 @@ If neither flag is set, all namespaces are scanned.
 |------|---------|------|---------|-------------|
 | `--profile-refresh-interval` | `TLS_COMPLIANCE_PROFILE_REFRESH_INTERVAL` | duration | `5m` | How often to re-fetch OpenShift TLS security profile configuration (APIServer, IngressController, KubeletConfig). Only used when running on OpenShift. Ignored on vanilla Kubernetes. |
 
+## Logging
+
+| Flag | Env Var | Type | Default | Description |
+|------|---------|------|---------|-------------|
+| `--log-format` | `TLS_COMPLIANCE_LOG_FORMAT` | string | `text` | Log output format. Use `text` for human-readable development logs or `json` for structured logs suitable for log aggregation pipelines (ELK, Splunk, CloudWatch). |
+
 ## Infrastructure
 
 These flags are standard controller-runtime/kubebuilder flags. They do not have
@@ -85,6 +92,10 @@ env:
   value: "kube-system,openshift-monitoring"
 - name: TLS_COMPLIANCE_CERT_EXPIRY_WARNING_DAYS
   value: "14"
+- name: TLS_COMPLIANCE_EXTRA_TLS_PORTS
+  value: "12345,54321"
+- name: TLS_COMPLIANCE_LOG_FORMAT
+  value: "json"
 ```
 
 ### CLI flags in container args
@@ -95,5 +106,7 @@ args:
 - --workers=10
 - --exclude-namespaces=kube-system,openshift-monitoring
 - --cert-expiry-warning-days=14
+- --extra-tls-ports=12345,54321
+- --log-format=json
 - --leader-elect
 ```

--- a/pkg/endpoint/resolver.go
+++ b/pkg/endpoint/resolver.go
@@ -307,10 +307,22 @@ func ExtractFromPod(pod *corev1.Pod) []Endpoint {
 	return endpoints
 }
 
+var defaultTLSPorts = map[int32]bool{
+	443: true, 8443: true, 9443: true,
+	2379: true, 5671: true, 6380: true, 9200: true,
+}
+
+var extraTLSPorts = map[int32]bool{}
+
+// SetExtraTLSPorts configures additional port numbers to treat as TLS endpoints.
+func SetExtraTLSPorts(ports map[int32]bool) {
+	extraTLSPorts = ports
+}
+
 // isTLSPortByNumberAndName checks if a port number and name indicate a TLS port.
 // Shared logic for both ServicePort and ContainerPort classification.
 func isTLSPortByNumberAndName(portNumber int32, portName string) bool {
-	if portNumber == 443 || portNumber == 8443 {
+	if defaultTLSPorts[portNumber] || extraTLSPorts[portNumber] {
 		return true
 	}
 

--- a/pkg/endpoint/resolver_test.go
+++ b/pkg/endpoint/resolver_test.go
@@ -329,8 +329,13 @@ func TestIsTLSPort(t *testing.T) {
 	}{
 		{"port 443", corev1.ServicePort{Port: 443}, true},
 		{"port 8443", corev1.ServicePort{Port: 8443}, true},
+		{"port 9443 (webhooks)", corev1.ServicePort{Port: 9443}, true},
+		{"port 2379 (etcd)", corev1.ServicePort{Port: 2379}, true},
+		{"port 5671 (AMQP TLS)", corev1.ServicePort{Port: 5671}, true},
+		{"port 6380 (Redis TLS)", corev1.ServicePort{Port: 6380}, true},
+		{"port 9200 (Elasticsearch)", corev1.ServicePort{Port: 9200}, true},
 		{"named https", corev1.ServicePort{Name: "https", Port: 9090}, true},
-		{"named https-metrics", corev1.ServicePort{Name: "https-metrics", Port: 9443}, true},
+		{"named https-metrics", corev1.ServicePort{Name: "https-metrics", Port: 7777}, true},
 		{"port 80", corev1.ServicePort{Port: 80}, false},
 		{"named http", corev1.ServicePort{Name: "http", Port: 80}, false},
 		{"named grpc", corev1.ServicePort{Name: "grpc", Port: 9090}, false},
@@ -354,8 +359,13 @@ func TestIsTLSContainerPort(t *testing.T) {
 	}{
 		{"port 443", corev1.ContainerPort{ContainerPort: 443}, true},
 		{"port 8443", corev1.ContainerPort{ContainerPort: 8443}, true},
-		{"named https", corev1.ContainerPort{Name: "https", ContainerPort: 9090}, true},
-		{"named https-metrics", corev1.ContainerPort{Name: "https-metrics", ContainerPort: 9443}, true},
+		{"port 9443 (webhooks)", corev1.ContainerPort{ContainerPort: 9443}, true},
+		{"port 2379 (etcd)", corev1.ContainerPort{ContainerPort: 2379}, true},
+		{"port 5671 (AMQP TLS)", corev1.ContainerPort{ContainerPort: 5671}, true},
+		{"port 6380 (Redis TLS)", corev1.ContainerPort{ContainerPort: 6380}, true},
+		{"port 9200 (Elasticsearch)", corev1.ContainerPort{ContainerPort: 9200}, true},
+		{"named https", corev1.ContainerPort{Name: "https", ContainerPort: 7777}, true},
+		{"named https-metrics", corev1.ContainerPort{Name: "https-metrics", ContainerPort: 7777}, true},
 		{"port 80", corev1.ContainerPort{ContainerPort: 80}, false},
 		{"named http", corev1.ContainerPort{Name: "http", ContainerPort: 80}, false},
 		{"named grpc", corev1.ContainerPort{Name: "grpc", ContainerPort: 9090}, false},
@@ -960,5 +970,47 @@ func TestExtractFromPod_DefaultProtocol(t *testing.T) {
 	endpoints := ExtractFromPod(pod)
 	if len(endpoints) != 1 {
 		t.Fatalf("expected 1 endpoint for port with default protocol, got %d", len(endpoints))
+	}
+}
+
+func TestSetExtraTLSPorts(t *testing.T) {
+	defer SetExtraTLSPorts(map[int32]bool{})
+
+	SetExtraTLSPorts(map[int32]bool{12345: true, 54321: true})
+
+	if !isTLSPort(corev1.ServicePort{Port: 12345}) {
+		t.Error("expected port 12345 to be detected as TLS after SetExtraTLSPorts")
+	}
+	if !isTLSContainerPort(corev1.ContainerPort{ContainerPort: 54321}) {
+		t.Error("expected port 54321 to be detected as TLS after SetExtraTLSPorts")
+	}
+	if isTLSPort(corev1.ServicePort{Port: 99999}) {
+		t.Error("unexpected TLS detection for port 99999")
+	}
+}
+
+func TestExtraTLSPorts_PodExtraction(t *testing.T) {
+	defer SetExtraTLSPorts(map[int32]bool{})
+
+	SetExtraTLSPorts(map[int32]bool{7777: true})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Ports: []corev1.ContainerPort{
+					{ContainerPort: 7777, Protocol: corev1.ProtocolTCP},
+				}},
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.244.1.5"},
+	}
+
+	endpoints := ExtractFromPod(pod)
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint for extra TLS port, got %d", len(endpoints))
+	}
+	if endpoints[0].Port != 7777 {
+		t.Errorf("port = %d, want 7777", endpoints[0].Port)
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -347,6 +347,56 @@ spec:
 		})
 	})
 
+	Context("Expanded TLS Port Detection", func() {
+		It("should detect a service on port 9443 as TLS by default", func() {
+			By("creating a service on port 9443 with a non-HTTPS name")
+			cmd := exec.Command("kubectl", "create", "service", "clusterip", "test-webhook-svc",
+				"--tcp=9443:9443", "-n", "default")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				cmd := exec.Command("kubectl", "delete", "service", "test-webhook-svc",
+					"-n", "default", "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			})
+
+			By("waiting for TLSComplianceReport to be created for port 9443")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "tlsreport", "-o",
+					"jsonpath={range .items[*]}{.spec.host},{.spec.port}{\"\\n\"}{end}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("test-webhook-svc.default,9443"),
+					"expected TLSComplianceReport for service on port 9443")
+			}).Should(Succeed())
+		})
+
+		It("should detect a service on port 2379 as TLS by default", func() {
+			By("creating a service on port 2379 (etcd)")
+			cmd := exec.Command("kubectl", "create", "service", "clusterip", "test-etcd-svc",
+				"--tcp=2379:2379", "-n", "default")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				cmd := exec.Command("kubectl", "delete", "service", "test-etcd-svc",
+					"-n", "default", "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			})
+
+			By("waiting for TLSComplianceReport to be created for port 2379")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "tlsreport", "-o",
+					"jsonpath={range .items[*]}{.spec.host},{.spec.port}{\"\\n\"}{end}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("test-etcd-svc.default,2379"),
+					"expected TLSComplianceReport for service on port 2379")
+			}).Should(Succeed())
+		})
+	})
+
 	Context("kubectl-tlsreport plugin", func() {
 		var pluginBinary string
 


### PR DESCRIPTION
## Summary

- **#116**: Expand default TLS port detection from 443/8443 to include 9443 (webhooks), 2379 (etcd), 5671 (AMQP TLS), 6380 (Redis TLS), and 9200 (Elasticsearch HTTPS)
- **#119**: Add `--extra-tls-ports` flag and `TLS_COMPLIANCE_EXTRA_TLS_PORTS` env var for user-defined custom ports (comma-separated, validated 1-65535)
- **#134**: Add `--log-format` flag and `TLS_COMPLIANCE_LOG_FORMAT` env var to switch between human-readable text and structured JSON logging for log aggregation pipelines

All flags follow existing patterns: CLI flag > env var > default, with validation in both paths.

## Changes

- `pkg/endpoint/resolver.go`: Replace hardcoded port check with `defaultTLSPorts` map, add `extraTLSPorts` package-level var with `SetExtraTLSPorts()` setter
- `cmd/main.go`: Two new flags, env var mappings, `parsePortList()` helper, log format wiring (env override applied before logger creation)
- `docs/configuration.md`: Document both new flags with examples
- Unit and E2E tests for all three features

Closes #116, Closes #119, Closes #134