### PR TITLE
Fix OCP SCC compatibility and NetworkPolicy egress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,5 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: tlscompliancereports.security.telco.openshift.io
 spec:
   group: security.telco.openshift.io

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancetargets.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancetargets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: tlscompliancetargets.security.telco.openshift.io
 spec:
   group: security.telco.openshift.io

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -8,9 +8,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/config/default/networkpolicy.yaml
+++ b/config/default/networkpolicy.yaml
@@ -38,12 +38,4 @@ spec:
         - port: 6443
           protocol: TCP
     # Allow TLS checks to any endpoint on any port
-    - ports:
-        - port: 443
-          protocol: TCP
-        - port: 8443
-          protocol: TCP
-        - port: 6443
-          protocol: TCP
-        - port: 9443
-          protocol: TCP
+    - {}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,9 +32,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## Summary

- Remove hardcoded UID 65532 from Dockerfile, manager.yaml, and manager_metrics_patch.yaml — the `distroless/static:nonroot` base image already ensures non-root execution, and hardcoded UIDs conflict with OpenShift's `restricted-v2` SCC which assigns UIDs from the namespace range
- Fix NetworkPolicy egress to allow TLS checks on any port — the previous policy only allowed ports 443/6443/8443/9443, causing all scans to timeout when endpoints listen on other ports (8081, 10250, 9090, etc.)

## Problem

On OpenShift, the operator pod fails to start with:

```
unable to validate against any security context constraint:
  provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: [65532]:
  65532 is not an allowed group
```

Even after the SCC issue is worked around, all TLS scans return `Timeout` because the NetworkPolicy blocks egress to most ports.

## Fix

- **Dockerfile**: Remove `USER 65532:65532` (line 31) — redundant with the `nonroot` base image
- **config/manager/manager.yaml**: Remove `runAsUser`, `runAsGroup`, `fsGroup` — keep `runAsNonRoot: true`
- **config/default/manager_metrics_patch.yaml**: Same UID removal
- **config/default/networkpolicy.yaml**: Replace port-specific egress with `- {}` to allow all outbound (the operator needs to scan arbitrary ports)

## Tested

Verified on OCP 4.22 (cnfdt16):
1. Pod starts without SCC workaround (`oc adm policy add-scc-to-user` not needed)
2. Controller acquires leader election and starts scanning
3. 90 endpoints discovered and scanned with correct compliance statuses (74 Compliant, 12 Closed, 2 Timeout, 1 NoTLS, 1 Unreachable)
4. `make lint` and `make test` pass