### PR TITLE
Fix hostname match false positives for Kubernetes services

### DIFF
--- a/pkg/tlscheck/checker_test.go
+++ b/pkg/tlscheck/checker_test.go
@@ -373,6 +373,59 @@ func TestParseCertificate(t *testing.T) {
 	}
 }
 
+func TestParseCertificate_KubernetesSuffixMatch(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "api.openshift-apiserver.svc",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames: []string{
+			"api.openshift-apiserver.svc",
+			"api.openshift-apiserver.svc.cluster.local",
+		},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	parsedCert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		hostname string
+		want     bool
+	}{
+		{"exact .svc match", "api.openshift-apiserver.svc", true},
+		{"exact .svc.cluster.local match", "api.openshift-apiserver.svc.cluster.local", true},
+		{"short name with suffix fallback", "api.openshift-apiserver", true},
+		{"unrelated hostname", "other-service.default", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			details := ParseCertificate(parsedCert, tt.hostname)
+			if details.HostnameMatch != tt.want {
+				t.Errorf("ParseCertificate(%q).HostnameMatch = %v, want %v", tt.hostname, details.HostnameMatch, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewTLSChecker_DefaultTimeout(t *testing.T) {
 	checker := NewTLSChecker(0)
 	if checker.Timeout != DefaultTimeout {

--- a/pkg/tlscheck/types.go
+++ b/pkg/tlscheck/types.go
@@ -97,6 +97,17 @@ func ParseCertificate(cert *x509.Certificate, hostname string) *CertificateDetai
 	daysUntilExpiry := int(cert.NotAfter.Sub(now).Hours() / 24)
 
 	hostnameMatch := cert.VerifyHostname(hostname) == nil
+	if !hostnameMatch {
+		// Kubernetes services are reachable by short name (name.namespace) but certs
+		// typically have the FQDN SANs (.svc, .svc.cluster.local). Try those suffixes
+		// before declaring a mismatch.
+		for _, suffix := range []string{".svc", ".svc.cluster.local"} {
+			if cert.VerifyHostname(hostname+suffix) == nil {
+				hostnameMatch = true
+				break
+			}
+		}
+	}
 
 	return &CertificateDetails{
 		Issuer:          cert.Issuer.String(),


### PR DESCRIPTION
## Summary

- Try `.svc` and `.svc.cluster.local` suffixes before declaring a hostname mismatch in `ParseCertificate`
- Service endpoints are resolved as `name.namespace` but certs from service-ca have SANs with the FQDN suffixes (`name.namespace.svc`, `name.namespace.svc.cluster.local`), producing false positives

## Problem

On a typical OCP 4.22 cluster, 63 of 74 compliant endpoints were reported as `hostnameMatch: false` because the operator checks the short hostname (e.g., `api.openshift-apiserver`) against certs that only have `.svc` and `.svc.cluster.local` SANs.

## Fix

In `pkg/tlscheck/types.go`, after the initial `cert.VerifyHostname(hostname)` fails, try appending `.svc` and `.svc.cluster.local` before setting `hostnameMatch = false`.

## Tests

Added `TestParseCertificate_KubernetesSuffixMatch` with 4 cases:
- Exact `.svc` match
- Exact `.svc.cluster.local` match  
- Short name with suffix fallback (the fix)
- Unrelated hostname (still false)