### PR TITLE
feat: add error metrics for Ingress/Route/Target reconciliation

### DIFF
--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -170,6 +170,7 @@ func (r *EndpointReconciler) ReconcileIngress(ctx context.Context, req ctrl.Requ
 	if err := r.Get(ctx, req.NamespacedName, &ing); err != nil {
 		if !apierrors.IsNotFound(err) {
 			logger.Error(err, "unable to fetch Ingress")
+			metrics.RecordReconcileError("Ingress", "fetch")
 		}
 		return
 	}
@@ -178,6 +179,7 @@ func (r *EndpointReconciler) ReconcileIngress(ctx context.Context, req ctrl.Requ
 	for _, ep := range endpoints {
 		if err := r.processEndpoint(ctx, ep); err != nil {
 			logger.Error(err, "failed to process Ingress endpoint", "host", ep.Host)
+			metrics.RecordReconcileError("Ingress", "process")
 		}
 	}
 }
@@ -197,6 +199,7 @@ func (r *EndpointReconciler) ReconcileRoute(ctx context.Context, req ctrl.Reques
 	if err := r.Get(ctx, req.NamespacedName, route); err != nil {
 		if !apierrors.IsNotFound(err) && ctx.Err() == nil {
 			logger.Error(err, "unable to fetch Route")
+			metrics.RecordReconcileError("Route", "fetch")
 		}
 		return
 	}
@@ -205,6 +208,7 @@ func (r *EndpointReconciler) ReconcileRoute(ctx context.Context, req ctrl.Reques
 	for _, ep := range endpoints {
 		if err := r.processEndpoint(ctx, ep); err != nil {
 			logger.Error(err, "failed to process Route endpoint", "host", ep.Host)
+			metrics.RecordReconcileError("Route", "process")
 		}
 	}
 }
@@ -217,6 +221,7 @@ func (r *EndpointReconciler) ReconcileTarget(ctx context.Context, req ctrl.Reque
 	if err := r.Get(ctx, req.NamespacedName, &target); err != nil {
 		if !apierrors.IsNotFound(err) {
 			logger.Error(err, "unable to fetch TLSComplianceTarget")
+			metrics.RecordReconcileError("Target", "fetch")
 		}
 		return
 	}
@@ -231,6 +236,7 @@ func (r *EndpointReconciler) ReconcileTarget(ctx context.Context, req ctrl.Reque
 
 	if err := r.processEndpoint(ctx, ep); err != nil {
 		logger.Error(err, "failed to process Target endpoint", "host", ep.Host, "port", ep.Port)
+		metrics.RecordReconcileError("Target", "process")
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -127,6 +127,16 @@ var (
 			Help:      "Total number of times TLS check retries were exhausted",
 		},
 	)
+
+	// ReconcileErrorsTotal tracks errors in resource-specific reconciliation handlers
+	ReconcileErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: MetricsNamespace,
+			Name:      "reconcile_errors_total",
+			Help:      "Total number of errors during resource reconciliation by source kind and error type",
+		},
+		[]string{"source_kind", "error_type"},
+	)
 )
 
 func init() {
@@ -141,6 +151,7 @@ func init() {
 		ScanCycleDurationSeconds,
 		CheckRetriesTotal,
 		CheckRetriesExhaustedTotal,
+		ReconcileErrorsTotal,
 	)
 }
 
@@ -207,4 +218,9 @@ func RecordRetry(reason string) {
 // RecordRetriesExhausted records that retries were exhausted for a TLS check
 func RecordRetriesExhausted() {
 	CheckRetriesExhaustedTotal.Inc()
+}
+
+// RecordReconcileError records an error during resource reconciliation
+func RecordReconcileError(sourceKind, errorType string) {
+	ReconcileErrorsTotal.WithLabelValues(sourceKind, errorType).Inc()
 }


### PR DESCRIPTION
## Summary

- Fixes #173
- `ReconcileIngress`, `ReconcileRoute`, and `ReconcileTarget` are event handlers that log errors but never increment any Prometheus counter — failures are invisible to monitoring
- Adds `tls_compliance_reconcile_errors_total` CounterVec with `source_kind` (`Ingress`, `Route`, `Target`) and `error_type` (`fetch`, `process`) labels
- Adds `RecordReconcileError()` helper in `internal/metrics/metrics.go`
- Incremented at all 6 error paths across the three handlers

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all unit tests pass
- [x] Tested against live OpenShift cluster (cnfdt16) — operator starts and runs cleanly