### PR TITLE
feat: add TLSComplianceTarget sample CR

### DIFF
--- a/config/samples/security_v1alpha1_tlscompliancetarget.yaml
+++ b/config/samples/security_v1alpha1_tlscompliancetarget.yaml
@@ -1,0 +1,7 @@
+apiVersion: security.telco.openshift.io/v1alpha1
+kind: TLSComplianceTarget
+metadata:
+  name: external-api-check
+spec:
+  host: api.example.com
+  port: 443


### PR DESCRIPTION
## Summary

- Fixes #175
- Adds `config/samples/security_v1alpha1_tlscompliancetarget.yaml` with an example TLSComplianceTarget resource
- Gives users a reference when creating custom scan targets

## Test plan

- [x] `make lint` — 0 issues