### PR TITLE
refactor: use wait.Backoff for retry cap and jitter

### DIFF
--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"math/rand/v2"
 	"net"
 	"strings"
 	"sync"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -380,13 +380,20 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 	}
 
 	maxAttempts := 1 + r.MaxRetries
-	backoff := r.RetryBackoff
-	if backoff <= 0 {
-		backoff = 30 * time.Second
+	retryBackoff := r.RetryBackoff
+	if retryBackoff <= 0 {
+		retryBackoff = 30 * time.Second
 	}
 	maxBackoff := r.MaxBackoff
 	if maxBackoff <= 0 {
 		maxBackoff = 5 * time.Minute
+	}
+	backoff := wait.Backoff{
+		Duration: retryBackoff,
+		Factor:   2,
+		Jitter:   0.25,
+		Steps:    maxAttempts,
+		Cap:      maxBackoff,
 	}
 
 	var result *tlscheck.TLSCheckResult
@@ -407,12 +414,7 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 
 		// Transient failure with retries remaining
 		if attempt < maxAttempts-1 {
-			retryDelay := backoff * time.Duration(1<<uint(attempt))
-			if retryDelay > maxBackoff {
-				retryDelay = maxBackoff
-			}
-			jitter := time.Duration(rand.Int64N(int64(retryDelay) / 4))
-			retryDelay += jitter
+			retryDelay := backoff.Step()
 			logger.Info("transient TLS check failure, retrying",
 				"attempt", attempt+1,
 				"maxAttempts", maxAttempts,


### PR DESCRIPTION
## Summary

- Replace hand-rolled exponential backoff with k8s.io/apimachinery/pkg/util/wait.Backoff — already a direct dependency, idiomatic for K8s operators
- Fixes a potential rand.Int64N(0) panic when retry delays are very small
- Removes math/rand/v2 import (the only caller)
- wait.Backoff handles cap, factor (2x), and jitter (25%) natively via Step()

## Test plan

- [x] make lint — 0 issues
- [x] make test — all pass
- [x] Existing TestEndpointReconciler_RetryBackoffCap still validates cap behavior
- [ ] CI passes