### PR TITLE
feat: add ExternalName Service endpoint discovery

### DIFF
--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -206,6 +206,71 @@ func TestEndpointReconciler_Reconcile_ServiceWithoutHTTPS(t *testing.T) {
 	}
 }
 
+func TestEndpointReconciler_Reconcile_ExternalNameService(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-api",
+			Namespace: testNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "api.vendor.example.com",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(svc).
+		WithStatusSubresource(&securityv1alpha1.TLSComplianceReport{}).
+		Build()
+
+	reconciler := &EndpointReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		CertExpiryDays: 30,
+	}
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "external-api",
+			Namespace: testNamespace,
+		},
+	}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Error("Reconcile() returned RequeueAfter != 0, want 0")
+	}
+
+	var crList securityv1alpha1.TLSComplianceReportList
+	if err := fakeClient.List(ctx, &crList); err != nil {
+		t.Fatalf("Failed to list TLSComplianceReports: %v", err)
+	}
+	if len(crList.Items) != 1 {
+		t.Fatalf("TLSComplianceReport count = %v, want 1", len(crList.Items))
+	}
+
+	cr := crList.Items[0]
+	if cr.Spec.Host != "api.vendor.example.com" {
+		t.Errorf("Host = %v, want api.vendor.example.com", cr.Spec.Host)
+	}
+	if cr.Spec.Port != 443 {
+		t.Errorf("Port = %v, want 443", cr.Spec.Port)
+	}
+	if cr.Spec.SourceKind != securityv1alpha1.SourceKindService {
+		t.Errorf("SourceKind = %v, want Service", cr.Spec.SourceKind)
+	}
+	if cr.Spec.SourceName != "external-api" {
+		t.Errorf("SourceName = %v, want external-api", cr.Spec.SourceName)
+	}
+}
+
 func TestEndpointReconciler_Reconcile_DeletedService(t *testing.T) {
 	ctx := context.Background()
 	scheme := newTestScheme()

--- a/pkg/endpoint/resolver.go
+++ b/pkg/endpoint/resolver.go
@@ -46,7 +46,13 @@ var sanitizeRegex = regexp.MustCompile(`[^a-z0-9-]`)
 
 // ExtractFromService returns TLS endpoints from a Service.
 // It looks for ports that are 443, 8443, or named https/https-*.
+// For ExternalName services, the host is spec.externalName and
+// port 443 is assumed when no ports are defined.
 func ExtractFromService(svc *corev1.Service) []Endpoint {
+	if svc.Spec.Type == corev1.ServiceTypeExternalName {
+		return extractFromExternalNameService(svc)
+	}
+
 	var endpoints []Endpoint
 
 	for _, port := range svc.Spec.Ports {
@@ -59,6 +65,39 @@ func ExtractFromService(svc *corev1.Service) []Endpoint {
 				SourceNamespace: svc.Namespace,
 				SourceName:      svc.Name,
 			})
+		}
+	}
+
+	return endpoints
+}
+
+func extractFromExternalNameService(svc *corev1.Service) []Endpoint {
+	host := svc.Spec.ExternalName
+	if host == "" {
+		return nil
+	}
+
+	var endpoints []Endpoint
+
+	if len(svc.Spec.Ports) == 0 {
+		endpoints = append(endpoints, Endpoint{
+			Host:            host,
+			Port:            443,
+			SourceKind:      "Service",
+			SourceNamespace: svc.Namespace,
+			SourceName:      svc.Name,
+		})
+	} else {
+		for _, port := range svc.Spec.Ports {
+			if isTLSPort(port) {
+				endpoints = append(endpoints, Endpoint{
+					Host:            host,
+					Port:            port.Port,
+					SourceKind:      "Service",
+					SourceNamespace: svc.Namespace,
+					SourceName:      svc.Name,
+				})
+			}
 		}
 	}
 

--- a/pkg/endpoint/resolver_test.go
+++ b/pkg/endpoint/resolver_test.go
@@ -147,6 +147,84 @@ func TestExtractFromService_MultiplePorts(t *testing.T) {
 	}
 }
 
+func TestExtractFromService_ExternalName(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-api",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "api.vendor.example.com",
+		},
+	}
+
+	endpoints := ExtractFromService(svc)
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(endpoints))
+	}
+
+	ep := endpoints[0]
+	if ep.Host != "api.vendor.example.com" {
+		t.Errorf("host = %q, want api.vendor.example.com", ep.Host)
+	}
+	if ep.Port != 443 {
+		t.Errorf("port = %d, want 443 (default for ExternalName without ports)", ep.Port)
+	}
+	if ep.SourceKind != "Service" {
+		t.Errorf("sourceKind = %q, want Service", ep.SourceKind)
+	}
+	if ep.SourceName != "external-api" {
+		t.Errorf("sourceName = %q, want external-api", ep.SourceName)
+	}
+}
+
+func TestExtractFromService_ExternalNameWithPorts(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-db",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "db.vendor.example.com",
+			Ports: []corev1.ServicePort{
+				{Name: "https", Port: 8443},
+				{Name: "http", Port: 80},
+			},
+		},
+	}
+
+	endpoints := ExtractFromService(svc)
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 TLS endpoint, got %d", len(endpoints))
+	}
+	if endpoints[0].Host != "db.vendor.example.com" {
+		t.Errorf("host = %q, want db.vendor.example.com", endpoints[0].Host)
+	}
+	if endpoints[0].Port != 8443 {
+		t.Errorf("port = %d, want 8443", endpoints[0].Port)
+	}
+}
+
+func TestExtractFromService_ExternalNameEmpty(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "broken-external",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "",
+		},
+	}
+
+	endpoints := ExtractFromService(svc)
+	if len(endpoints) != 0 {
+		t.Fatalf("expected 0 endpoints for empty ExternalName, got %d", len(endpoints))
+	}
+}
+
 func TestExtractFromIngress(t *testing.T) {
 	ing := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -252,6 +252,37 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 	})
 
+	Context("Positive: ExternalName Service Detection", Label("service-detection"), func() {
+		It("should create report for an ExternalName Service", func() {
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(`apiVersion: v1
+kind: Service
+metadata:
+  name: test-external-api
+  namespace: default
+spec:
+  type: ExternalName
+  externalName: kubernetes.default.svc.cluster.local
+`)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				cmd := exec.Command("kubectl", "delete", "service", "test-external-api",
+					"-n", "default", "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			})
+
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "tlsreport", "-o",
+					"jsonpath={range .items[*]}{.spec.host},{.spec.port},{.spec.sourceName}{\"\\n\"}{end}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("kubernetes.default.svc.cluster.local,443,test-external-api"))
+			}).Should(Succeed())
+		})
+	})
+
 	Context("Positive: Pod Detection", Label("pod-detection"), func() {
 		const agnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.53"
 


### PR DESCRIPTION
## Summary

- ExternalName services were silently skipped — the resolver used `{name}.{namespace}` as host, which doesn't resolve for ExternalName types
- Now checks `svc.Spec.Type == ExternalName` and uses `spec.externalName` as the scan target
- Defaults to port 443 when no ports are defined (common for ExternalName), otherwise filters by TLS port detection as usual
- Empty `externalName` field is handled gracefully (returns no endpoints)

## ExternalName Service Discovery Examples

### Creating an ExternalName Service

```yaml
apiVersion: v1
kind: Service
metadata:
  name: test-external-api
  namespace: default
spec:
  type: ExternalName
  externalName: kubernetes.default.svc.cluster.local
```

### Report output

```
$ kubectl get tlsreport -o jsonpath='{range .items[*]}{.spec.host},{.spec.port},{.spec.sourceName},{.status.complianceStatus}{"\n"}{end}' | grep external
kubernetes.default.svc.cluster.local,443,test-external-api,Compliant
```

The report uses the external hostname as the scan target (not `test-external-api.default`):

```yaml
spec:
  host: kubernetes.default.svc.cluster.local
  port: 443
  sourceKind: Service
  sourceName: test-external-api
  sourceNamespace: default
status:
  complianceStatus: Compliant
  complianceGrade: A
  certificateInfo:
    daysUntilExpiry: 22
    dnsNames:
    - kubernetes
    - kubernetes.default
    - kubernetes.default.svc
    - kubernetes.default.svc.cluster.local
    hostnameMatch: true
    issuer: CN=kube-apiserver-service-network-signer,OU=openshift
  cipherSuites:
    TLS 1.2:
    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
    TLS 1.3:
    - TLS_AES_128_GCM_SHA256
  tlsVersions:
    tls13: true
    tls12: true
    tls10: false
    ssl30: false
```

### Wide output

```
$ kubectl get tlsreport -o wide | grep kubernetes.default.svc
kubernetes-default-svc-cluster-local-443-ef7919f2   kubernetes.default.svc.cluster.local   443   Service   Compliant   A   true   true   true   false   false   PQCReady   22
```

## Cluster validation

Validated on cnfdt16 (OCP 4.18, K8s v1.35.5) — ExternalName service discovered, scanned, and reported as Compliant with Grade A.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all pass, endpoint coverage 96.4% -> 96.8%
- [x] 3 new unit tests: ExternalName default port, ExternalName with explicit ports, empty ExternalName
- [x] 1 new controller test: reconcile creates CR with external hostname
- [x] 1 new E2E test: ExternalName service pointing at `kubernetes.default.svc.cluster.local`
- [x] Live cluster validation on cnfdt16 (OCP 4.18) — Compliant, Grade A
- [x] CI passes (all 12 checks green)

Closes #130