### PR TITLE
ci: add quick install instructions to release notes

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -124,3 +124,30 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.event.release.tag_name }} dist/install.yaml --clobber
+
+      - name: Add install instructions to release notes
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          REPO="${{ github.repository }}"
+          EXISTING_BODY=$(gh release view "$TAG" --json body --jq '.body')
+          read -r -d '' INSTALL_SECTION << 'SECTION' || true
+          ## Quick Install
+
+          ```bash
+          kubectl apply -f https://github.com/REPO_PLACEHOLDER/releases/download/TAG_PLACEHOLDER/install.yaml
+          ```
+
+          To uninstall:
+
+          ```bash
+          kubectl delete -f https://github.com/REPO_PLACEHOLDER/releases/download/TAG_PLACEHOLDER/install.yaml
+          ```
+          SECTION
+          INSTALL_SECTION=$(echo "$INSTALL_SECTION" | sed 's/^          //')
+          INSTALL_SECTION="${INSTALL_SECTION//REPO_PLACEHOLDER/$REPO}"
+          INSTALL_SECTION="${INSTALL_SECTION//TAG_PLACEHOLDER/$TAG}"
+          printf '%s\n\n%s' "$INSTALL_SECTION" "$EXISTING_BODY" > /tmp/release-body.md
+          gh release edit "$TAG" --notes-file /tmp/release-body.md


### PR DESCRIPTION
## Summary

- Automatically prepends a "Quick Install" section to every GitHub release with `kubectl apply` and `kubectl delete` commands
- Uses the exact tag-specific URL so each release has a self-contained install command
- Runs as a final step in the existing build-push workflow after `install.yaml` is uploaded

## Example output

The release body will be prepended with:

```markdown
## Quick Install

\`\`\`bash
kubectl apply -f https://github.com/sebrandon1/tls-compliance-operator/releases/download/v1.0.13/install.yaml
\`\`\`

To uninstall:

\`\`\`bash
kubectl delete -f https://github.com/sebrandon1/tls-compliance-operator/releases/download/v1.0.13/install.yaml
\`\`\`
```

Also retroactively applied to [v1.0.13](https://github.com/sebrandon1/tls-compliance-operator/releases/tag/v1.0.13).

## Test plan

- [x] Heredoc output tested locally — produces clean markdown
- [x] Retroactively applied to v1.0.13 to verify the format
- [x] Lint passes