### PR TITLE
fix: align CertificateExpiringSoon alert threshold with operator default

### DIFF
--- a/config/prometheus/alerting-rules.yaml
+++ b/config/prometheus/alerting-rules.yaml
@@ -22,7 +22,7 @@ spec:
             runbook_url: "https://github.com/sebrandon1/tls-compliance-operator#compliance-logic"
 
         - alert: TLSCertificateExpiringSoon
-          expr: tls_compliance_certificate_expiry_days > 0 and tls_compliance_certificate_expiry_days < 7
+          expr: tls_compliance_certificate_expiry_days > 0 and tls_compliance_certificate_expiry_days < 30
           for: 10m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary

- Changes the `TLSCertificateExpiringSoon` alert threshold from `< 7` to `< 30` days to match the operator's `--cert-expiry-warning-days` default
- Eliminates the 23-day gap where the operator emits `CertificateExpiring` warnings but the Prometheus alert stays silent

## Test plan

- [x] Lint passes
- [x] Alert expression now matches the default flag value

Closes #204