### PR TITLE
feat: add periodic scan and cleanup health check metrics

### DIFF
--- a/config/prometheus/alerting-rules.yaml
+++ b/config/prometheus/alerting-rules.yaml
@@ -51,6 +51,26 @@ spec:
             description: "The 95th percentile scan cycle duration is {{ $value | humanizeDuration }}, exceeding the 5-minute threshold."
             runbook_url: "https://github.com/sebrandon1/tls-compliance-operator#compliance-logic"
 
+        - alert: TLSScanCycleStalled
+          expr: time() - tls_compliance_scan_cycle_last_completed_timestamp > 7200
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "TLS periodic scan cycle is stalled"
+            description: "No scan cycle has completed in over 2 hours (default interval is 1 hour). The periodic scan goroutine may be stuck or crashed."
+            runbook_url: "https://github.com/sebrandon1/tls-compliance-operator#compliance-logic"
+
+        - alert: TLSCleanupCycleStalled
+          expr: time() - tls_compliance_cleanup_cycle_last_completed_timestamp > 600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "TLS cleanup cycle is stalled"
+            description: "No cleanup cycle has completed in over 10 minutes (default interval is 5 minutes). The cleanup goroutine may be stuck or crashed."
+            runbook_url: "https://github.com/sebrandon1/tls-compliance-operator#compliance-logic"
+
         - alert: TLSEndpointUnreachable
           expr: tls_compliance_endpoints_total{status="Unreachable"} > 0
           for: 24h

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,6 +10,8 @@ All metrics use the `tls_compliance_` prefix.
 | `tls_compliance_version_support` | Gauge | `host`, `port`, `version` | TLS version support (1=yes, 0=no) |
 | `tls_compliance_reconcile_total` | Counter | `result` | Reconciliation attempts |
 | `tls_compliance_scan_cycle_duration_seconds` | Histogram | - | Full scan cycle duration |
+| `tls_compliance_scan_cycle_last_completed_timestamp` | Gauge | - | Unix timestamp of last successful scan cycle |
+| `tls_compliance_cleanup_cycle_last_completed_timestamp` | Gauge | - | Unix timestamp of last successful cleanup cycle |
 
 ## Example PromQL Queries
 
@@ -25,6 +27,9 @@ tls_compliance_version_support{version="1.0"} == 1
 
 # Average TLS check duration
 histogram_quantile(0.95, rate(tls_compliance_check_duration_seconds_bucket[5m]))
+
+# Detect stalled scan loop (no completion in 2 hours)
+time() - tls_compliance_scan_cycle_last_completed_timestamp > 7200
 ```
 
 ## ServiceMonitor

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -883,6 +883,8 @@ func (r *EndpointReconciler) StartPeriodicScan(ctx context.Context, interval tim
 
 				if err := r.scanAllEndpoints(ctx); err != nil {
 					logger.Error(err, "failed to complete periodic scan")
+				} else {
+					metrics.RecordScanCycleCompleted()
 				}
 
 				duration := time.Since(start)
@@ -1037,6 +1039,8 @@ func (r *EndpointReconciler) StartCleanupLoop(ctx context.Context, interval time
 			case <-ticker.C:
 				if err := r.cleanupOrphanedCRs(ctx); err != nil {
 					logger.Error(err, "failed to cleanup orphaned CRs")
+				} else {
+					metrics.RecordCleanupCycleCompleted()
 				}
 			}
 		}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -137,6 +137,24 @@ var (
 		},
 		[]string{"source_kind", "error_type"},
 	)
+
+	// ScanCycleLastCompletedTimestamp records the Unix timestamp of the last successful periodic scan
+	ScanCycleLastCompletedTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "scan_cycle_last_completed_timestamp",
+			Help:      "Unix timestamp of the last completed periodic scan cycle",
+		},
+	)
+
+	// CleanupCycleLastCompletedTimestamp records the Unix timestamp of the last successful cleanup
+	CleanupCycleLastCompletedTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: MetricsNamespace,
+			Name:      "cleanup_cycle_last_completed_timestamp",
+			Help:      "Unix timestamp of the last completed cleanup cycle",
+		},
+	)
 )
 
 func init() {
@@ -152,6 +170,8 @@ func init() {
 		CheckRetriesTotal,
 		CheckRetriesExhaustedTotal,
 		ReconcileErrorsTotal,
+		ScanCycleLastCompletedTimestamp,
+		CleanupCycleLastCompletedTimestamp,
 	)
 }
 
@@ -223,4 +243,14 @@ func RecordRetriesExhausted() {
 // RecordReconcileError records an error during resource reconciliation
 func RecordReconcileError(sourceKind, errorType string) {
 	ReconcileErrorsTotal.WithLabelValues(sourceKind, errorType).Inc()
+}
+
+// RecordScanCycleCompleted sets the scan cycle timestamp to the current time
+func RecordScanCycleCompleted() {
+	ScanCycleLastCompletedTimestamp.SetToCurrentTime()
+}
+
+// RecordCleanupCycleCompleted sets the cleanup cycle timestamp to the current time
+func RecordCleanupCycleCompleted() {
+	CleanupCycleLastCompletedTimestamp.SetToCurrentTime()
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func gaugeValue(g prometheus.Gauge) float64 {
+	m := &dto.Metric{}
+	_ = g.Write(m)
+	return m.GetGauge().GetValue()
+}
+
+func assertTimestampGaugeSetToNow(t *testing.T, recordFn func(), gauge prometheus.Gauge) {
+	t.Helper()
+	before := float64(time.Now().Unix())
+	recordFn()
+	after := float64(time.Now().Unix()) + 1
+
+	val := gaugeValue(gauge)
+	if val < before || val > after {
+		t.Errorf("expected timestamp between %v and %v, got %v", before, after, val)
+	}
+}
+
+func TestRecordScanCycleCompleted(t *testing.T) {
+	assertTimestampGaugeSetToNow(t, RecordScanCycleCompleted, ScanCycleLastCompletedTimestamp)
+}
+
+func TestRecordCleanupCycleCompleted(t *testing.T) {
+	assertTimestampGaugeSetToNow(t, RecordCleanupCycleCompleted, CleanupCycleLastCompletedTimestamp)
+}


### PR DESCRIPTION
## Summary

- Add `tls_compliance_scan_cycle_last_completed_timestamp` and `tls_compliance_cleanup_cycle_last_completed_timestamp` gauges that update on each successful cycle completion
- Add `TLSScanCycleStalled` Prometheus alert that fires when no scan completes in 2 hours (2x the default 1-hour interval)
- Add metrics tests and update docs/metrics.md with the new metrics and a staleness PromQL example

Closes #200

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CI passes