### PR TITLE
ci: add SBOM generation to release workflow

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -113,6 +113,21 @@ jobs:
             --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}
 
+      - name: Generate SBOM
+        if: github.event_name == 'release'
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-push.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} sbom.spdx.json --clobber
+
       - name: Generate install manifest
         if: github.event_name == 'release'
         run: |


### PR DESCRIPTION
## Summary

- Add SPDX JSON SBOM generation using `anchore/sbom-action` after cosign signing
- Upload `sbom.spdx.json` as a release asset alongside `install.yaml`
- Enables downstream users and security scanners to audit container image dependencies

Closes #197

## Test plan

- [ ] CI passes (workflow syntax validation)
- [ ] Next release produces `sbom.spdx.json` as a downloadable release asset