### PR TITLE
ci: add major version tag update on release

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,0 +1,39 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Update major version tag
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          echo "Release tag: $TAG_NAME"
+
+          if [[ $TAG_NAME =~ ^v([0-9]+)\. ]]; then
+            MAJOR_VERSION="v${BASH_REMATCH[1]}"
+            echo "Major version: $MAJOR_VERSION"
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            git tag -d "$MAJOR_VERSION" 2>/dev/null || true
+            git tag -fa "$MAJOR_VERSION" -m "Update $MAJOR_VERSION to $TAG_NAME"
+            git push origin "$MAJOR_VERSION" --force
+
+            echo "Successfully updated $MAJOR_VERSION tag to point to $TAG_NAME"
+          else
+            echo "Tag $TAG_NAME does not match expected format (vX.Y.Z), skipping major version update"
+          fi


### PR DESCRIPTION
## Summary

- Add workflow that updates the `v1` git tag to point to the latest release on each publish
- Keeps the git tag in sync with the container image `v1` tag already produced by `docker/metadata-action`
- Matches the pattern used in [openshift-kni/olm-annotation-lint](https://github.com/openshift-kni/olm-annotation-lint/blob/main/.github/workflows/update-major-tag.yml)

## Test plan

- [ ] CI passes
- [ ] Next release creates/updates the `v1` tag on GitHub