### PR TITLE
feat: add cert issuer/subject filters and kustomize overlays

### DIFF
--- a/cmd/kubectl-tlsreport/main.go
+++ b/cmd/kubectl-tlsreport/main.go
@@ -75,6 +75,8 @@ Use --kubeconfig and --context to target a specific cluster.`,
 	rootCmd.PersistentFlags().StringVar(&filterOpts.PQCStatus, "pqc-status", "", "Filter by PQC readiness (PQCReady, TLS13Capable, LegacyTLS, NoPQC)")
 	rootCmd.PersistentFlags().StringVar(&filterOpts.ExpiresWithin, "expires-within", "", "Show certs expiring within duration (e.g. 30d, 7d, 90d)")
 	rootCmd.PersistentFlags().BoolVar(&filterOpts.Expired, "expired", false, "Show only expired certificates")
+	rootCmd.PersistentFlags().StringVar(&filterOpts.Issuer, "cert-issuer", "", "Filter by certificate issuer (substring match)")
+	rootCmd.PersistentFlags().StringVar(&filterOpts.Subject, "cert-subject", "", "Filter by certificate subject (substring match)")
 	rootCmd.PersistentFlags().StringVar(&sortBy, "sort-by", "", "Sort results by field (host, port, compliance, expiry, grade, pqc)")
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use")
 	rootCmd.PersistentFlags().StringVar(&kubecontext, "context", "", "The kubeconfig context to use")

--- a/config/overlays/high-availability/kustomization.yaml
+++ b/config/overlays/high-availability/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default
+
+patches:
+- target:
+    kind: Deployment
+  patch: |-
+    - op: replace
+      path: /spec/replicas
+      value: 3
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/limits/memory
+      value: 512Mi
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/requests/memory
+      value: 128Mi

--- a/config/overlays/low-resource/kustomization.yaml
+++ b/config/overlays/low-resource/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default
+
+patches:
+- target:
+    kind: Deployment
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/limits/cpu
+      value: 250m
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/limits/memory
+      value: 128Mi
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/requests/cpu
+      value: 5m
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/requests/memory
+      value: 32Mi

--- a/pkg/export/filter.go
+++ b/pkg/export/filter.go
@@ -39,12 +39,17 @@ type FilterOptions struct {
 	ExpiresWithin string
 	// Expired filters to only expired certificates.
 	Expired bool
+	// Issuer filters by certificate issuer (case-insensitive substring match).
+	Issuer string
+	// Subject filters by certificate subject (case-insensitive substring match).
+	Subject string
 }
 
 // IsEmpty returns true if no filters are set.
 func (o FilterOptions) IsEmpty() bool {
 	return o.Namespace == "" && o.Status == "" && o.Source == "" &&
-		o.PQCStatus == "" && o.ExpiresWithin == "" && !o.Expired
+		o.PQCStatus == "" && o.ExpiresWithin == "" && !o.Expired &&
+		o.Issuer == "" && o.Subject == ""
 }
 
 // FilterReports returns the subset of reports matching all non-empty filter criteria.
@@ -117,6 +122,16 @@ func matchesFilter(r *securityv1alpha1.TLSComplianceReport, opts FilterOptions, 
 		}
 		expiry := r.Status.CertificateInfo.NotAfter.Time
 		if expiry.Before(now) || expiry.After(now.Add(expiresWithin)) {
+			return false
+		}
+	}
+	if opts.Issuer != "" {
+		if r.Status.CertificateInfo == nil || !strings.Contains(strings.ToLower(r.Status.CertificateInfo.Issuer), strings.ToLower(opts.Issuer)) {
+			return false
+		}
+	}
+	if opts.Subject != "" {
+		if r.Status.CertificateInfo == nil || !strings.Contains(strings.ToLower(r.Status.CertificateInfo.Subject), strings.ToLower(opts.Subject)) {
 			return false
 		}
 	}

--- a/pkg/export/filter_test.go
+++ b/pkg/export/filter_test.go
@@ -318,6 +318,101 @@ func TestFilterReports_CombinedWithPQC(t *testing.T) {
 	}
 }
 
+func TestFilterReports_ByIssuer(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "a.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{Issuer: "CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US"},
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "b.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{Issuer: "CN=DigiCert Global Root G2,O=DigiCert Inc,C=US"},
+			},
+		},
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "c.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{Issuer: "let's encrypt"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(filtered))
+	}
+	if filtered[0].Spec.Host != "a.test" {
+		t.Errorf("expected a.test, got %s", filtered[0].Spec.Host)
+	}
+}
+
+func TestFilterReports_BySubject(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "a.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{Subject: "CN=api.example.com"},
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "b.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				CertificateInfo: &securityv1alpha1.CertificateInfo{Subject: "CN=*.internal.corp"},
+			},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{Subject: "example.com"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(filtered))
+	}
+	if filtered[0].Spec.Host != "a.test" {
+		t.Errorf("expected a.test, got %s", filtered[0].Spec.Host)
+	}
+}
+
+func TestFilterReports_CombinedIssuerAndStatus(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "a.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusCompliant,
+				CertificateInfo:  &securityv1alpha1.CertificateInfo{Issuer: "CN=Self-Signed"},
+			},
+		},
+		{
+			Spec: securityv1alpha1.TLSComplianceReportSpec{Host: "b.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{
+				ComplianceStatus: securityv1alpha1.ComplianceStatusNonCompliant,
+				CertificateInfo:  &securityv1alpha1.CertificateInfo{Issuer: "CN=Self-Signed"},
+			},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{Issuer: "self-signed", Status: "NonCompliant"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(filtered))
+	}
+	if filtered[0].Spec.Host != "b.test" {
+		t.Errorf("expected b.test, got %s", filtered[0].Spec.Host)
+	}
+}
+
+func TestFilterReports_NoCertExcludedByIssuer(t *testing.T) {
+	reports := []securityv1alpha1.TLSComplianceReport{
+		{
+			Spec:   securityv1alpha1.TLSComplianceReportSpec{Host: "nocert.test", Port: 443, SourceKind: securityv1alpha1.SourceKindService},
+			Status: securityv1alpha1.TLSComplianceReportStatus{},
+		},
+	}
+
+	filtered, _ := FilterReports(reports, FilterOptions{Issuer: "anything"})
+	if len(filtered) != 0 {
+		t.Errorf("expected 0 reports for nil cert info, got %d", len(filtered))
+	}
+}
+
 func TestParseExpiresWithin(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Summary

- Add `--cert-issuer` and `--cert-subject` flags to `kubectl-tlsreport` for case-insensitive substring filtering by certificate issuer and subject — enables security teams to quickly find endpoints by CA or CN (e.g., `--cert-issuer "let's encrypt"` or `--cert-subject "*.internal.corp"`)
- Add low-resource kustomize overlay (`config/overlays/low-resource/`) for dev, edge, and single-node clusters with reduced CPU/memory
- Add high-availability kustomize overlay (`config/overlays/high-availability/`) with 3 replicas and increased memory for production deployments

Closes #201, closes #203

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass, export coverage 88.5% → 88.8%
- [x] 4 new filter tests: by issuer, by subject, combined with status, nil cert excluded