### PR TITLE
feat: enable race detector in CI test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test -race $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 .PHONY: benchmark
 benchmark: ## Run Go benchmark tests.


### PR DESCRIPTION
## Summary

- Add `-race` flag to `make test` so data races in the concurrent controller goroutines (periodic scan, cleanup loop, reconcile) are caught during CI
- All existing tests pass cleanly with the race detector enabled

## Test plan

- [x] `make test` passes with `-race` flag
- [x] `make lint` passes