### PR TITLE
feat: add version subcommand to kubectl-tlsreport plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,11 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
+PLUGIN_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
 .PHONY: build-plugin
 build-plugin: fmt vet ## Build kubectl-tlsreport plugin binary.
-	go build -o bin/kubectl-tlsreport ./cmd/kubectl-tlsreport
+	go build -ldflags "-X main.version=$(PLUGIN_VERSION)" -o bin/kubectl-tlsreport ./cmd/kubectl-tlsreport
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/cmd/kubectl-tlsreport/main.go
+++ b/cmd/kubectl-tlsreport/main.go
@@ -41,6 +41,8 @@ func init() {
 	utilruntime.Must(securityv1alpha1.AddToScheme(scheme))
 }
 
+var version = "dev"
+
 var (
 	filterOpts  export.FilterOptions
 	sortBy      string
@@ -84,6 +86,7 @@ Use --kubeconfig and --context to target a specific cluster.`,
 	rootCmd.AddCommand(newSummaryCmd())
 	rootCmd.AddCommand(newGetCmd())
 	rootCmd.AddCommand(newDescribeCmd())
+	rootCmd.AddCommand(newVersionCmd())
 
 	return rootCmd
 }
@@ -114,6 +117,16 @@ func newGetCmd() *cobra.Command {
   # Get non-compliant endpoints in a namespace
   kubectl tlsreport get --status NonCompliant -n production`,
 		RunE: runGet,
+	}
+}
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the plugin version",
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Println("kubectl-tlsreport " + version)
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `kubectl tlsreport version` subcommand to identify installed plugin version
- Version is injected at build time via `-ldflags` from `git describe --tags`
- Defaults to `dev` when built without ldflags

## Test plan

- [x] `make build-plugin && bin/kubectl-tlsreport version` prints version
- [x] `make lint` passes