### PR TITLE
feat: add certificate chain length and public key details

### DIFF
--- a/api/v1alpha1/tlscompliancereport_types.go
+++ b/api/v1alpha1/tlscompliancereport_types.go
@@ -120,6 +120,18 @@ type CertificateInfo struct {
 	// HostnameMatch indicates whether the certificate is valid for the tested endpoint hostname
 	// +optional
 	HostnameMatch *bool `json:"hostnameMatch,omitempty"`
+	// ChainLength is the number of certificates in the peer certificate chain
+	// +optional
+	ChainLength int `json:"chainLength,omitempty"`
+	// PublicKeyAlgorithm is the certificate's public key algorithm (e.g. RSA, ECDSA, Ed25519)
+	// +optional
+	PublicKeyAlgorithm string `json:"publicKeyAlgorithm,omitempty"`
+	// PublicKeyBits is the size of the public key in bits
+	// +optional
+	PublicKeyBits int `json:"publicKeyBits,omitempty"`
+	// SignatureAlgorithm is the algorithm used to sign the certificate (e.g. SHA256-RSA, ECDSA-SHA256)
+	// +optional
+	SignatureAlgorithm string `json:"signatureAlgorithm,omitempty"`
 }
 
 // TLSProfileComplianceResult contains the result of checking an endpoint

--- a/cmd/kubectl-tlsreport/main.go
+++ b/cmd/kubectl-tlsreport/main.go
@@ -289,6 +289,15 @@ func printReportDetail(r securityv1alpha1.TLSComplianceReport) error {
 		if cert.HostnameMatch != nil {
 			_, _ = fmt.Fprintf(w, "  Hostname Match:   %v\n", *cert.HostnameMatch)
 		}
+		if cert.PublicKeyAlgorithm != "" {
+			_, _ = fmt.Fprintf(w, "  Public Key:       %s (%d bits)\n", cert.PublicKeyAlgorithm, cert.PublicKeyBits)
+		}
+		if cert.SignatureAlgorithm != "" {
+			_, _ = fmt.Fprintf(w, "  Signature Alg:    %s\n", cert.SignatureAlgorithm)
+		}
+		if cert.ChainLength > 0 {
+			_, _ = fmt.Fprintf(w, "  Chain Length:     %d\n", cert.ChainLength)
+		}
 		if len(cert.DNSNames) > 0 {
 			_, _ = fmt.Fprintf(w, "  DNS Names:        %s\n", strings.Join(cert.DNSNames, ", "))
 		}

--- a/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
+++ b/config/crd/bases/security.telco.openshift.io_tlscompliancereports.yaml
@@ -152,6 +152,10 @@ spec:
               certificateInfo:
                 description: CertificateInfo contains details about the TLS certificate
                 properties:
+                  chainLength:
+                    description: ChainLength is the number of certificates in the
+                      peer certificate chain
+                    type: integer
                   daysUntilExpiry:
                     description: DaysUntilExpiry is the number of days until the certificate
                       expires
@@ -181,6 +185,17 @@ spec:
                     description: NotBefore is the start of the certificate's validity
                       period
                     format: date-time
+                    type: string
+                  publicKeyAlgorithm:
+                    description: PublicKeyAlgorithm is the certificate's public key
+                      algorithm (e.g. RSA, ECDSA, Ed25519)
+                    type: string
+                  publicKeyBits:
+                    description: PublicKeyBits is the size of the public key in bits
+                    type: integer
+                  signatureAlgorithm:
+                    description: SignatureAlgorithm is the algorithm used to sign
+                      the certificate (e.g. SHA256-RSA, ECDSA-SHA256)
                     type: string
                   subject:
                     description: Subject is the certificate subject

--- a/internal/controller/endpoint_controller.go
+++ b/internal/controller/endpoint_controller.go
@@ -507,14 +507,18 @@ func (r *EndpointReconciler) performTLSCheck(ctx context.Context, crName, host s
 			notAfter := metav1.NewTime(result.Certificate.NotAfter)
 			hostnameMatch := result.Certificate.HostnameMatch
 			cr.Status.CertificateInfo = &securityv1alpha1.CertificateInfo{
-				Issuer:          result.Certificate.Issuer,
-				Subject:         result.Certificate.Subject,
-				NotBefore:       &notBefore,
-				NotAfter:        &notAfter,
-				DNSNames:        result.Certificate.DNSNames,
-				IsExpired:       result.Certificate.IsExpired,
-				DaysUntilExpiry: result.Certificate.DaysUntilExpiry,
-				HostnameMatch:   &hostnameMatch,
+				Issuer:             result.Certificate.Issuer,
+				Subject:            result.Certificate.Subject,
+				NotBefore:          &notBefore,
+				NotAfter:           &notAfter,
+				DNSNames:           result.Certificate.DNSNames,
+				IsExpired:          result.Certificate.IsExpired,
+				DaysUntilExpiry:    result.Certificate.DaysUntilExpiry,
+				HostnameMatch:      &hostnameMatch,
+				ChainLength:        result.Certificate.ChainLength,
+				PublicKeyAlgorithm: result.Certificate.PublicKeyAlgorithm,
+				PublicKeyBits:      result.Certificate.PublicKeyBits,
+				SignatureAlgorithm: result.Certificate.SignatureAlgorithm,
 			}
 		}
 

--- a/pkg/export/csv.go
+++ b/pkg/export/csv.go
@@ -34,6 +34,7 @@ var CSVHeader = []string{
 	"TLS1.3", "TLS1.2", "TLS1.1", "TLS1.0", "SSL3.0",
 	"QuantumReady", "PQCReadiness",
 	"CertExpiry", "CertIssuer",
+	"PubKeyAlgorithm", "PubKeyBits", "SignatureAlgorithm", "ChainLength",
 }
 
 // WriteCSV writes TLSComplianceReport items as CSV to the given writer.
@@ -89,6 +90,18 @@ func formatKeyExchangeTypes(keTypes map[string]string) string {
 func reportToCSVRow(r *securityv1alpha1.TLSComplianceReport) []string {
 	certExpiry, certIssuer := extractCertInfo(r)
 
+	pubKeyAlg, pubKeyBits, sigAlg, chainLen := "", "", "", ""
+	if r.Status.CertificateInfo != nil {
+		pubKeyAlg = r.Status.CertificateInfo.PublicKeyAlgorithm
+		if r.Status.CertificateInfo.PublicKeyBits > 0 {
+			pubKeyBits = strconv.Itoa(r.Status.CertificateInfo.PublicKeyBits)
+		}
+		sigAlg = r.Status.CertificateInfo.SignatureAlgorithm
+		if r.Status.CertificateInfo.ChainLength > 0 {
+			chainLen = strconv.Itoa(r.Status.CertificateInfo.ChainLength)
+		}
+	}
+
 	return []string{
 		r.Spec.Host,
 		strconv.Itoa(int(r.Spec.Port)),
@@ -108,5 +121,9 @@ func reportToCSVRow(r *securityv1alpha1.TLSComplianceReport) []string {
 		string(r.Status.PQCReadiness),
 		certExpiry,
 		certIssuer,
+		pubKeyAlg,
+		pubKeyBits,
+		sigAlg,
+		chainLen,
 	}
 }

--- a/pkg/export/json.go
+++ b/pkg/export/json.go
@@ -27,24 +27,28 @@ import (
 
 // JSONReport is the JSON representation of a single TLS compliance report.
 type JSONReport struct {
-	Host             string            `json:"host"`
-	Port             string            `json:"port"`
-	Source           string            `json:"source"`
-	Namespace        string            `json:"namespace"`
-	Name             string            `json:"name"`
-	Compliance       string            `json:"compliance"`
-	Grade            string            `json:"grade"`
-	ForwardSecrecy   bool              `json:"forwardSecrecy"`
-	KeyExchangeTypes map[string]string `json:"keyExchangeTypes,omitempty"`
-	TLS13            bool              `json:"tls13"`
-	TLS12            bool              `json:"tls12"`
-	TLS11            bool              `json:"tls11"`
-	TLS10            bool              `json:"tls10"`
-	SSL30            bool              `json:"ssl30"`
-	QuantumReady     bool              `json:"quantumReady"`
-	PQCReadiness     string            `json:"pqcReadiness"`
-	CertExpiry       string            `json:"certExpiry"`
-	CertIssuer       string            `json:"certIssuer"`
+	Host               string            `json:"host"`
+	Port               string            `json:"port"`
+	Source             string            `json:"source"`
+	Namespace          string            `json:"namespace"`
+	Name               string            `json:"name"`
+	Compliance         string            `json:"compliance"`
+	Grade              string            `json:"grade"`
+	ForwardSecrecy     bool              `json:"forwardSecrecy"`
+	KeyExchangeTypes   map[string]string `json:"keyExchangeTypes,omitempty"`
+	TLS13              bool              `json:"tls13"`
+	TLS12              bool              `json:"tls12"`
+	TLS11              bool              `json:"tls11"`
+	TLS10              bool              `json:"tls10"`
+	SSL30              bool              `json:"ssl30"`
+	QuantumReady       bool              `json:"quantumReady"`
+	PQCReadiness       string            `json:"pqcReadiness"`
+	CertExpiry         string            `json:"certExpiry"`
+	CertIssuer         string            `json:"certIssuer"`
+	PublicKeyAlgorithm string            `json:"publicKeyAlgorithm,omitempty"`
+	PublicKeyBits      int               `json:"publicKeyBits,omitempty"`
+	SignatureAlgorithm string            `json:"signatureAlgorithm,omitempty"`
+	ChainLength        int               `json:"chainLength,omitempty"`
 }
 
 // WriteJSON writes TLSComplianceReport items as pretty-printed JSON to the given writer.
@@ -66,7 +70,7 @@ func WriteJSON(w io.Writer, reports []securityv1alpha1.TLSComplianceReport) erro
 func reportToJSON(r *securityv1alpha1.TLSComplianceReport) JSONReport {
 	certExpiry, certIssuer := extractCertInfo(r)
 
-	return JSONReport{
+	jr := JSONReport{
 		Host:             r.Spec.Host,
 		Port:             strconv.Itoa(int(r.Spec.Port)),
 		Source:           string(r.Spec.SourceKind),
@@ -86,4 +90,13 @@ func reportToJSON(r *securityv1alpha1.TLSComplianceReport) JSONReport {
 		CertExpiry:       certExpiry,
 		CertIssuer:       certIssuer,
 	}
+
+	if r.Status.CertificateInfo != nil {
+		jr.PublicKeyAlgorithm = r.Status.CertificateInfo.PublicKeyAlgorithm
+		jr.PublicKeyBits = r.Status.CertificateInfo.PublicKeyBits
+		jr.SignatureAlgorithm = r.Status.CertificateInfo.SignatureAlgorithm
+		jr.ChainLength = r.Status.CertificateInfo.ChainLength
+	}
+
+	return jr
 }

--- a/pkg/tlscheck/checker.go
+++ b/pkg/tlscheck/checker.go
@@ -225,6 +225,7 @@ func (c *TLSChecker) tryTLSVersion(ctx context.Context, addr, serverName string,
 	var certDetails *CertificateDetails
 	if len(state.PeerCertificates) > 0 {
 		certDetails = ParseCertificate(state.PeerCertificates[0], serverName)
+		certDetails.ChainLength = len(state.PeerCertificates)
 	}
 
 	return true, cipherSuiteName, curve, certDetails, nil

--- a/pkg/tlscheck/checker_test.go
+++ b/pkg/tlscheck/checker_test.go
@@ -371,6 +371,15 @@ func TestParseCertificate(t *testing.T) {
 	if len(details.DNSNames) == 0 {
 		t.Error("expected DNS names to be populated")
 	}
+	if details.PublicKeyAlgorithm == "" {
+		t.Error("expected public key algorithm to be populated")
+	}
+	if details.PublicKeyBits <= 0 {
+		t.Errorf("expected positive public key bits, got %d", details.PublicKeyBits)
+	}
+	if details.SignatureAlgorithm == "" {
+		t.Error("expected signature algorithm to be populated")
+	}
 }
 
 func TestParseCertificate_KubernetesSuffixMatch(t *testing.T) {

--- a/pkg/tlscheck/types.go
+++ b/pkg/tlscheck/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package tlscheck
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"crypto/x509"
 	"time"
 )
@@ -80,14 +83,18 @@ type TLSCheckResult struct {
 
 // CertificateDetails contains parsed certificate information
 type CertificateDetails struct {
-	Issuer          string
-	Subject         string
-	NotBefore       time.Time
-	NotAfter        time.Time
-	DNSNames        []string
-	IsExpired       bool
-	DaysUntilExpiry int
-	HostnameMatch   bool
+	Issuer             string
+	Subject            string
+	NotBefore          time.Time
+	NotAfter           time.Time
+	DNSNames           []string
+	IsExpired          bool
+	DaysUntilExpiry    int
+	HostnameMatch      bool
+	ChainLength        int
+	PublicKeyAlgorithm string
+	PublicKeyBits      int
+	SignatureAlgorithm string
 }
 
 // ParseCertificate extracts CertificateDetails from an x509 certificate.
@@ -110,13 +117,29 @@ func ParseCertificate(cert *x509.Certificate, hostname string) *CertificateDetai
 	}
 
 	return &CertificateDetails{
-		Issuer:          cert.Issuer.String(),
-		Subject:         cert.Subject.String(),
-		NotBefore:       cert.NotBefore,
-		NotAfter:        cert.NotAfter,
-		DNSNames:        cert.DNSNames,
-		IsExpired:       now.After(cert.NotAfter),
-		DaysUntilExpiry: daysUntilExpiry,
-		HostnameMatch:   hostnameMatch,
+		Issuer:             cert.Issuer.String(),
+		Subject:            cert.Subject.String(),
+		NotBefore:          cert.NotBefore,
+		NotAfter:           cert.NotAfter,
+		DNSNames:           cert.DNSNames,
+		IsExpired:          now.After(cert.NotAfter),
+		DaysUntilExpiry:    daysUntilExpiry,
+		HostnameMatch:      hostnameMatch,
+		PublicKeyAlgorithm: cert.PublicKeyAlgorithm.String(),
+		PublicKeyBits:      publicKeyBits(cert),
+		SignatureAlgorithm: cert.SignatureAlgorithm.String(),
+	}
+}
+
+func publicKeyBits(cert *x509.Certificate) int {
+	switch key := cert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		return key.N.BitLen()
+	case *ecdsa.PublicKey:
+		return key.Curve.Params().BitSize
+	case ed25519.PublicKey:
+		return 256
+	default:
+		return 0
 	}
 }


### PR DESCRIPTION
## Summary

- Expose certificate chain length, public key algorithm/size, and signature algorithm from TLS handshake results
- Data was already available in `state.PeerCertificates[0]` during the handshake but not extracted
- New fields appear in CRD status, `kubectl tlsreport describe`, CSV export, and JSON export
- Closes #118

## Changes

- `pkg/tlscheck/types.go`: Add `ChainLength`, `PublicKeyAlgorithm`, `PublicKeyBits`, `SignatureAlgorithm` to `CertificateDetails`; extract via `ParseCertificate` and `publicKeyBits()` helper
- `pkg/tlscheck/checker.go`: Set `ChainLength` from `len(state.PeerCertificates)` in `tryTLSVersion`
- `api/v1alpha1/tlscompliancereport_types.go`: Add corresponding fields to `CertificateInfo` CRD struct
- `internal/controller/endpoint_controller.go`: Map new fields from check result to CR status
- `cmd/kubectl-tlsreport/main.go`: Display new fields in `describe` output
- `pkg/export/csv.go`: Add 4 new CSV columns
- `pkg/export/json.go`: Add 4 new JSON fields

## Test plan

- [x] Existing `TestParseCertificate` tests extended with new field assertions
- [x] `make manifests generate` regenerates CRD and DeepCopy
- [x] `make test` — all tests pass
- [x] `make lint` — clean